### PR TITLE
Support full Cloudinary URLs as the `src` prop

### DIFF
--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -45,7 +45,7 @@ const CldImage = props => {
   // an Image component prop as opposed to simply the URL
   //
   // https://nextjs.org/docs/api-reference/next/image#blurdataurl
-  if (imageProps.placeholder) {
+  if ( imageProps.placeholder ) {
     let publicId = getPublicId(props.src);
 
     imageProps.blurDataURL = createPlaceholderUrl({

--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -1,7 +1,10 @@
 import Image from 'next/image';
 
-import { createPlaceholderUrl } from '../../lib/cloudinary';
-import { cloudinaryLoader, transformationPlugins } from '../../loaders/cloudinary-loader';
+import { createPlaceholderUrl, getPublicId } from '../../lib/cloudinary';
+import {
+  cloudinaryLoader,
+  transformationPlugins
+} from '../../loaders/cloudinary-loader';
 
 const CldImage = props => {
 
@@ -42,10 +45,11 @@ const CldImage = props => {
   // an Image component prop as opposed to simply the URL
   //
   // https://nextjs.org/docs/api-reference/next/image#blurdataurl
+  if (imageProps.placeholder) {
+    let publicId = getPublicId(props.src);
 
-  if ( imageProps.placeholder ) {
     imageProps.blurDataURL = createPlaceholderUrl({
-      src: props.src,
+      src: publicId,
       placeholder: props.placeholder
     });
 

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -11,21 +11,39 @@ const cld = new Cloudinary({
 });
 
 /**
+ * Retrieves the public id of a cloudiary image url, with or without the version, depending on the url passed.
+ * Or just returns it if it is not recognized as a cloudiary image url.
+ *
+ * @param {string} src The cloudiary url or public id.
+ *
+ * @return {string} The images public id
+ */
+export function getPublicId(src) {
+  if ( src.includes('res.cloudinary.com' )) {
+    const urlParts = src.split('/');
+    const hasVersion = urlParts[urlParts.length - 3].match(/v[0-9]+/);
+    return urlParts.slice(hasVersion ? -3 : -2).join('/');
+  }
+  return src;
+}
+
+/**
  * createPlaceholderUrl
  */
 
 export function createPlaceholderUrl({ src, placeholder }) {
-  const cldImage = cld.image(src)
-                      .resize('c_limit,w_100')
-                      .delivery('q_1')
-                      .format('auto');
+  const cldImage = cld
+    .image(src)
+    .resize('c_limit,w_100')
+    .delivery('q_1')
+    .format('auto');
 
   if ( placeholder === 'grayscale' ) {
     cldImage.effect('e_grayscale');
   }
 
   if ( placeholder.includes('color:') ) {
-    const color = placeholder.split(':').splice(1).join(':')
+    const color = placeholder.split(':').splice(1).join(':');
     cldImage.effect('e_grayscale');
     cldImage.effect(`e_colorize:60,co_${color}`);
   }

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -19,7 +19,7 @@ const cld = new Cloudinary({
  * @return {string} The images public id
  */
 export function getPublicId(src) {
-  if ( src.includes('res.cloudinary.com' )) {
+  if ( src.includes('res.cloudinary.com') ) {
     const urlParts = src.split('/');
     const hasVersion = urlParts[urlParts.length - 3].match(/v[0-9]+/);
     return urlParts.slice(hasVersion ? -3 : -2).join('/');

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -25,14 +25,13 @@ export function getPublicId(src) {
 
     const withTransformations = src.match(regexWithTransformations)
     const withoutTransformations = src.match(regexWithoutTransformations)
-    
+
     if ( withTransformations ) {
       return withTransformations[withTransformations.length - 1]
     } else if ( withoutTransformations ) {
       return withoutTransformations[withoutTransformations.length - 1]
     } else {
       console.warn(`Not possible to retrieve the publicUrl from ${src}, make sure it's a valid cloudiary image url.`)
-      return src
     }
   }
   return src;

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -11,8 +11,8 @@ const cld = new Cloudinary({
 });
 
 /**
- * Retrieves the public id of a cloudiary image url, with or without the version, depending on the url passed.
- * Or just returns it if it is not recognized as a cloudiary image url.
+ * Retrieves the public id of a cloudiary image url. If no url is recognized it returns the parameter it self.
+ * If it's recognized that is a url and it's not possible to get the public id, it warns the user.
  *
  * @param {string} src The cloudiary url or public id.
  *
@@ -20,9 +20,20 @@ const cld = new Cloudinary({
  */
 export function getPublicId(src) {
   if ( src.includes('res.cloudinary.com') ) {
-    const urlParts = src.split('/');
-    const hasVersion = urlParts[urlParts.length - 3].match(/v[0-9]+/);
-    return urlParts.slice(hasVersion ? -3 : -2).join('/');
+    const regexWithTransformations = /(https?)\:\/\/(res.cloudinary.com)\/([^\/]+)\/(image|video|raw)\/(upload|authenticated)\/(.*)\/(v[0-9]+)\/(.+)(?:\.[a-z]{3})?/
+    const regexWithoutTransformations = /(https?)\:\/\/(res.cloudinary.com)\/([^\/]+)\/(image|video|raw)\/(upload|authenticated)\/(v[0-9]+)\/(.+)(?:\.[a-z]{3})?/
+
+    const withTransformations = src.match(regexWithTransformations)
+    const withoutTransformations = src.match(regexWithoutTransformations)
+    
+    if ( withTransformations ) {
+      return withTransformations[withTransformations.length - 1]
+    } else if ( withoutTransformations ) {
+      return withoutTransformations[withoutTransformations.length - 1]
+    } else {
+      console.warn(`Not possible to retrieve the publicUrl from ${src}, make sure it's a valid cloudiary image url.`)
+      return src
+    }
   }
   return src;
 }

--- a/next-cloudinary/src/loaders/cloudinary-loader.js
+++ b/next-cloudinary/src/loaders/cloudinary-loader.js
@@ -1,4 +1,5 @@
 import { Cloudinary } from '@cloudinary/url-gen';
+import { getPublicId } from '../lib/cloudinary';
 
 import * as croppingPlugin from '../plugins/cropping';
 import * as overlaysPlugin from '../plugins/overlays';
@@ -38,15 +39,17 @@ export function cloudinaryLoader(defaultOptions, cldOptions) {
     quality: 'auto',
     ...defaultOptions
   };
+  let publicId = getPublicId(options.src);
 
-  const cldImage = cld.image(options.src);
+  const cldImage = cld.image(publicId);
 
   transformationPlugins.forEach(({ plugin }) => {
-    const { options: pluginOptions } = plugin({
-      cldImage,
-      options,
-      cldOptions
-    }) || {};
+    const { options: pluginOptions } =
+      plugin({
+        cldImage,
+        options,
+        cldOptions
+      }) || {};
 
     if ( pluginOptions?.format ) {
       options.format = pluginOptions.format;
@@ -54,7 +57,7 @@ export function cloudinaryLoader(defaultOptions, cldOptions) {
   });
 
   return cldImage
-          .format(options.format)
-          .delivery(`q_${options.quality}`)
-          .toURL();
+    .format(options.format)
+    .delivery(`q_${options.quality}`)
+    .toURL();
 }


### PR DESCRIPTION
Issue #2 

This PR enables the `src` prop to receive the image cloudiary url. It only retrieves the public id from the url and passes it forward. It passes the version as well, if it is present in the url.

This PR does not solves the transformation case discussed in #9 