### PR TITLE
Implement initial polling for image processing

### DIFF
--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -3,6 +3,17 @@ import Image from 'next/future/image';
 import { createPlaceholderUrl, getPublicId } from '../../lib/cloudinary';
 import { cloudinaryLoader, transformationPlugins } from '../../loaders/cloudinary-loader';
 
+function pollImage(imageOptions, options, cldOptions) {
+  try {
+    let res = fetch(cloudinaryLoader({ ...imageOptions, options }, cldOptions));
+    if (res.ok) {
+      return res.json();
+    } else if (res.status == 423) {
+      return pollImage(imageOptions, options, cldOptions);
+    }
+  } catch (e) {}
+}
+
 const CldImage = props => {
 
   const CLD_OPTIONS = [];
@@ -60,6 +71,9 @@ const CldImage = props => {
     <Image
       {...imageProps}
       loader={(options) => cloudinaryLoader({ ...imageProps, options }, cldOptions)}
+      onError={(options) => {
+        pollImage(imageProps, options, cldOptions);     
+      }}
     />
   );
 }

--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -8,10 +8,15 @@ function pollImage(imageOptions, options, cldOptions) {
     let res = fetch(cloudinaryLoader({ ...imageOptions, options }, cldOptions));
     if (res.ok) {
       return res.json();
-    } else if (res.status == 423) {
+    }
+  } catch (e) {
+    if (e.statusCode == 423) {
+      await (new Promise((resolve) => {
+        setTimeout(() => resolve(), 500);
+      }));
       return pollImage(imageOptions, options, cldOptions);
     }
-  } catch (e) {}
+  }
 }
 
 const CldImage = props => {


### PR DESCRIPTION
# Description

Implements image polling on the client side so that when using transformations which require processing and return a 423 status code, the image loads upon completion. This intends to use the `onError` function available for `next/future/image` components. For polling, the general approach is that when an error occurs, a simple fetch is made to the image URL. We will check the response and then continue polling until it's available if it's a 423 status code.

## Issue Ticket Number

Fixes #1 

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
