### PR TITLE
Extract transformations and effect in url construct

### DIFF
--- a/docs/pages/components/cldimage/basic-usage.mdx
+++ b/docs/pages/components/cldimage/basic-usage.mdx
@@ -47,6 +47,17 @@ You can further take advantage of Cloudinary features like background removal an
 />
 ```
 
+You can also take advantage of Cloudinary features like auto parsing of transformations from src as you can add all transformations at once like `<Cld Url>/<Transformations>/<Version>/<Public Id>`
+
+```
+<CldImage
+  width="600"
+  height="600"
+  src="<Url Containing Transformations>" 
+  preserveTransformations={true}
+/>
+```
+
 As CldImage is a wrapper around the Next.js Image component, all built-in Image component features will work out-of-the-box including the `layout` prop.
 
 ## Learn More about CldImage

--- a/docs/pages/components/cldimage/configuration.mdx
+++ b/docs/pages/components/cldimage/configuration.mdx
@@ -36,6 +36,7 @@ import OgImage from '../../../components/OgImage';
 | quality      | string | `"auto"`   | `"90"`    |
 | format       | string | `"auto"`   | `"webp"`  |
 | deliveryType | string | `"upload"` | `"fetch"` |
+| preserveTransformations | string | `false` | `true` |
 
 ## Effect Props
 

--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -475,3 +475,14 @@ import ImageGrid from '../../../components/ImageGrid';
     ```
   </li>
 </ImageGrid>
+
+<ImageGrid>
+  <li>
+    <CldImage
+      width="960"
+      height="600"
+      src={`${process.env.EXAMPLES_DIRECTORY}/c_fill,h_300,w_250/e_blur:300/turtle`}
+      preserveTransformations
+    />
+  </li>
+</ImageGrid>

--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -56,9 +56,9 @@ const CldImage = props => {
     }
   }
 
-  if (props.src && props.useUrlTransformations) {
-    const transformations = getTransformations(props.src, props.useUrlTransformations);
-    imageProps.rawTransformations = transformations;
+  if (props.src && props.preserveTransformations) {
+    const transformations = getTransformations(props.src,props.preserveTransformations);
+    imageProps.rawTransformations = [...imageProps.rawTransformations,...transformations,];
   }
 
   return (

--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 
-import { createPlaceholderUrl, getPublicId, transformationPlugins } from '../../lib/cloudinary';
+import { createPlaceholderUrl, getPublicId, transformationPlugins, getTransformations } from '../../lib/cloudinary';
 import { cloudinaryLoader } from '../../loaders/cloudinary-loader';
 
 const CldImage = props => {
@@ -54,6 +54,11 @@ const CldImage = props => {
     if ( imageProps.placeholder !== 'blur' ) {
       imageProps.placeholder = 'blur';
     }
+  }
+
+  if (props.src && props.useUrlTransformations) {
+    const transformations = getTransformations(props.src, props.useUrlTransformations);
+    imageProps.rawTransformations = transformations;
   }
 
   return (

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -104,27 +104,36 @@ export function getPublicId(src) {
 
   return src;
 }
-export function getTransformations(src, useUrlTransformations) {
-  if ( typeof src !== 'string' ) {
+
+/**
+ * Retrieves the transformations added to a cloudiary image url. If no transformation is recognized it returns an empty array.
+ *
+ * @param {string} src The cloudiary url.
+ *
+ * @return {array} The array of transformations
+ */
+
+ export function getTransformations(src, preserveTransformations) {
+  if (typeof src !== "string") {
     throw new Error(`Invalid src of type ${typeof src}`);
   }
 
-  if (src.includes('res.cloudinary.com') && useUrlTransformations) {
+  if (src.includes("res.cloudinary.com") && preserveTransformations) {
     const regex = new RegExp(
       "(https?)://(res.cloudinary.com)/([^/]+)/(image|video|raw)/(upload|authenticated)/(.*)/(v[0-9]+)/(.+)(?:.[a-z]{3})?",
-      "gim"
+      "gi"
     );
     const groups = regex.exec(src);
-    const transformationStr = groups
-      .slice(1)
-      .find((i) => i.includes(_) && i.includes(","));
+    const transformationStr = groups.slice(1).find((i) => i.includes("_"));
 
-    if(transformationStr){
-      return transformationStr.split(",")
-    }else{
-      return []
+    if (transformationStr) {
+      return transformationStr.split(",").join("/").split("/");
+    } else {
+      return [];
     }
   }
+
+  return [];
 }
 
 /**

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -104,6 +104,28 @@ export function getPublicId(src) {
 
   return src;
 }
+export function getTransformations(src, useUrlTransformations) {
+  if ( typeof src !== 'string' ) {
+    throw new Error(`Invalid src of type ${typeof src}`);
+  }
+
+  if (src.includes('res.cloudinary.com') && useUrlTransformations) {
+    const regex = new RegExp(
+      "(https?)://(res.cloudinary.com)/([^/]+)/(image|video|raw)/(upload|authenticated)/(.*)/(v[0-9]+)/(.+)(?:.[a-z]{3})?",
+      "gim"
+    );
+    const groups = regex.exec(src);
+    const transformationStr = groups
+      .slice(1)
+      .find((i) => i.includes(_) && i.includes(","));
+
+    if(transformationStr){
+      return transformationStr.split(",")
+    }else{
+      return []
+    }
+  }
+}
 
 /**
  * createPlaceholderUrl

--- a/next-cloudinary/tests/lib/cloudinary.spec.js
+++ b/next-cloudinary/tests/lib/cloudinary.spec.js
@@ -1,4 +1,4 @@
-import { constructCloudinaryUrl, getPublicId, createPlaceholderUrl } from '../../src/lib/cloudinary';
+import { constructCloudinaryUrl, getPublicId, getTransformations, createPlaceholderUrl } from '../../src/lib/cloudinary';
 
 // Mock console.warn() so we can see when it's called
 global.console = {
@@ -81,6 +81,34 @@ describe('Cloudinary', () => {
       expect(getPublicId(src)).toBe(src)
       expect(console.warn)
         .toBeCalledWith(`Not possible to retrieve the publicUrl from ${src}, make sure it's a valid cloudinary image url.`)
+    });
+  });
+
+  describe("getTransformations", () => {
+    it("gets a non-Cloudinary url", () => {
+      const src = "https://google.com";
+      expect(getTransformations(src, true)).toEqual([]);
+    });
+
+    it("returns the transformations of a Cloudinary URL with a single transformation", () => {
+      const src = `https://res.cloudinary.com/test-cloud/image/upload/w_960/v1/app/images/turtle`;
+      expect(getTransformations(src, true)).toEqual(["w_960"]);
+    });
+
+    it("returns the transformations of a Cloudinary URL with multiple transformations", () => {
+      const src = `https://res.cloudinary.com/test-cloud/image/upload/c_limit,w_960/v1/app/images/turtle`;
+      expect(getTransformations(src, true)).toEqual(["c_limit", "w_960"]);
+    });
+
+    it("returns the transformations of a Cloudinary URL with multiple transformations with / delimiter", () => {
+      const src = `https://res.cloudinary.com/test-cloud/image/upload/c_limit,w_960/f_auto/q_auto/v1/app/images/turtle`;
+      expect(getTransformations(src, true)).toEqual(["c_limit","w_960","f_auto","q_auto"]);
+    });
+
+    it("Returns invalid url with a warning", () => {
+      const src = 245;
+      expect(() => {getTransformations(src, true)}).toThrow(Error);
+      expect(() => {getTransformations(src, true)}).toThrow(`Invalid src of type number`);
     });
   });
 


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Used the regex to extract the URL transformations and add to the cloudinaryUrlConstructor with the permission of the new useUrlTransformations property

## Issue Ticket Number

Fixes  #9 


## Type of change
- added a new property for allowing user to make a choice to use URL transformation
- extract transformations from URL using regex
- ran changes correctly
- test 

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
