### PR TITLE
Fixing: External Links According To  Label On Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ import { CldImage } from 'next-cloudinary';
 ### Other Use Cases
 
 * [Background Removal](https://next-cloudinary.spacejelly.dev/use-cases/background-removal)
-* [Image Overlays](https://next-cloudinary.spacejelly.dev/use-cases/image-underlays)
-* [Image Underlays](https://next-cloudinary.spacejelly.dev/use-cases/image-overlays)
+* [Image Overlays](https://next-cloudinary.spacejelly.dev/use-cases/image-overlays)
+* [Image Underlays](https://next-cloudinary.spacejelly.dev/use-cases/image-underlays)
 * [Social Media Card](https://next-cloudinary.spacejelly.dev/use-cases/social-media-card)
 * [Text Overlays](https://next-cloudinary.spacejelly.dev/use-cases/text-overlays)
 


### PR DESCRIPTION
# Description

This pr fixes wrong external urls on some labels from readme

## Issue Ticket Number

#66 

Fixes 

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes needed to the documentation
