### PR TITLE
Named Transformations

### DIFF
--- a/docs/pages/components/cldimage/configuration.mdx
+++ b/docs/pages/components/cldimage/configuration.mdx
@@ -25,6 +25,7 @@ import OgImage from '../../../components/OgImage';
 | rawTransformations | array              | `['e_blur:2000']`            |
 | removeBackground   | bool/string        | `true`                       |
 | text               | string             | `"Next Cloudinary"`          |
+| transformations    | string/array       | `['my-named-transformation']`|
 | underlay           | string             | `"my-public-id"`             |
 | underlays          | array              | See Below                    |
 | zoompan            | bool/string/object | See Below                    |

--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -459,6 +459,25 @@ import ImageGrid from '../../../components/ImageGrid';
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="100vw"
+      transformations={[
+        'next-cloudinary-named-transformation'
+      ]}
+    />
+
+    ### Named Transformations
+
+    ```jsx
+    transformations={[
+      'next-cloudinary-named-transformation'
+    ]}
+    ```
+  </li>
+  <li>
+    <CldImage
+      width="960"
+      height="600"
+      src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
+      sizes="100vw"
       rawTransformations={[
         'e_blur:2000',
         'e_tint:100:0000FF:0p:FF1493:100p'

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -3,6 +3,7 @@ import { Cloudinary } from '@cloudinary/url-gen';
 import * as croppingPlugin from '../plugins/cropping';
 import * as effectsPlugin from '../plugins/effects';
 import * as overlaysPlugin from '../plugins/overlays';
+import * as namedTransformationsPlugin from '../plugins/named-transformations';
 import * as rawTransformationsPlugin from '../plugins/raw-transformations';
 import * as removeBackgroundPlugin from '../plugins/remove-background';
 import * as underlaysPlugin from '../plugins/underlays';
@@ -21,6 +22,7 @@ export const transformationPlugins = [
   croppingPlugin,
   effectsPlugin,
   overlaysPlugin,
+  namedTransformationsPlugin,
   underlaysPlugin,
   zoompanPlugin,
 

--- a/next-cloudinary/src/plugins/named-transformations.js
+++ b/next-cloudinary/src/plugins/named-transformations.js
@@ -1,0 +1,13 @@
+export const props = ['transformations'];
+
+export function plugin({ cldImage, options } = {}) {
+  let { transformations = [] } = options;
+
+  if ( !Array.isArray(transformations) ) {
+    transformations = [transformations];
+  }
+
+  transformations.forEach(transformation => {
+    cldImage.addTransformation(`t_${transformation}`);
+  });
+}

--- a/next-cloudinary/tests/plugins/named-transformations.spec.js
+++ b/next-cloudinary/tests/plugins/named-transformations.spec.js
@@ -1,0 +1,52 @@
+import { Cloudinary } from '@cloudinary/url-gen';
+
+import * as namedTransformationsPlugin from '../../src/plugins/named-transformations';
+
+const { plugin } = namedTransformationsPlugin
+
+const cld = new Cloudinary({
+  cloud: {
+    cloudName: 'test-cloud-name'
+  }
+});
+
+const TEST_PUBLIC_ID = 'test-public-id';
+
+describe('Plugins', () => {
+  describe('Named Transformations', () => {
+    it('should apply a single named transformation to a Cloudinary URL', () => {
+
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const options = {
+        transformations: 'my-transformation'
+      }
+
+      plugin({
+        cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`t_${options.transformations}/${TEST_PUBLIC_ID}`);
+    });
+
+    it('should apply an array of named transformations to a Cloudinary URL', () => {
+
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const options = {
+        transformations: [
+          'my-transformation',
+          'my-other-transformation'
+        ]
+      }
+
+      plugin({
+        cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`t_${options.transformations.join('/t_')}/${TEST_PUBLIC_ID}`);
+    })
+  });
+});


### PR DESCRIPTION
# Description

Adds the ability to pass in a named transformation:
```
<CldImage
  transformations="my-transformation"
```

As a single one, or multiple as:

```
<CldImage
  transformations={['my-transformation', 'my-other-transformation']}
```

## Issue Ticket Number

Fixes #68 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
