### PR TITLE
Zoom

### DIFF
--- a/docs/components/ImageGrid/ImageGrid.module.scss
+++ b/docs/components/ImageGrid/ImageGrid.module.scss
@@ -10,4 +10,12 @@
     grid-template-columns: repeat(2, calc(50% - 1.5em));
   }
 
+  &[data-column-count="2"] {
+
+    @media (max-width: 480px) {
+      grid-template-columns: 1fr;
+    }
+
+  }
+
 }

--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -435,7 +435,7 @@ import ImageGrid from '../../../components/ImageGrid';
         text: {
           color: 'blueviolet',
           fontFamily: 'Source Sans Pro',
-          fontSize: 250,
+          fontSize: 160,
           fontWeight: 'bold',
           textDecoration: 'underline',
           letterSpacing: 14,
@@ -458,7 +458,7 @@ import ImageGrid from '../../../components/ImageGrid';
       text: {
         color: 'blueviolet',
         fontFamily: 'Source Sans Pro',
-        fontSize: 120,
+        fontSize: 160,
         fontWeight: 'bold',
         textDecoration: 'underline',
         letterSpacing: 14,

--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -27,7 +27,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       removeBackground
     />
 
@@ -46,7 +46,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       zoompan="loop"
     />
 
@@ -61,7 +61,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       blur="1200"
     />
 
@@ -76,7 +76,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       pixelate
     />
 
@@ -91,7 +91,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       grayscale
     />
 
@@ -106,7 +106,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       tint="equalize:80:blue:blueviolet"
     />
 
@@ -128,7 +128,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="600"
       height="900"
       src={`${process.env.EXAMPLES_DIRECTORY}/woman-headphones`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       crop="thumb"
       gravity="auto"
     />
@@ -141,7 +141,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="600"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/woman-headphones`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       crop="thumb"
       gravity="auto"
     />
@@ -158,7 +158,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="600"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/woman-headphones`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       crop="thumb"
       gravity="faces"
     />
@@ -168,6 +168,25 @@ import ImageGrid from '../../../components/ImageGrid';
     ```jsx
     crop="thumb"
     gravity="faces"
+    ```
+  </li>
+  <li>
+    <CldImage
+      width="600"
+      height="600"
+      src={`${process.env.EXAMPLES_DIRECTORY}/woman-headphones`}
+      sizes="(max-width: 480px) 100vw, 50vw"
+      crop="thumb"
+      gravity="faces"
+      zoom="0.5"
+    />
+
+    ### Thumbnail with Faces Gravity and Zoom
+
+    ```jsx
+    crop="thumb"
+    gravity="faces"
+    zoom="0.5"
     ```
   </li>
 </ImageGrid>
@@ -180,7 +199,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       placeholder="blur"
     />
 
@@ -195,7 +214,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       placeholder="grayscale"
     />
 
@@ -210,7 +229,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       placeholder="color:blueviolet"
     />
 
@@ -230,9 +249,9 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       overlays={[{
-        publicId: 'images/earth',
+        publicId: `${process.env.EXAMPLES_DIRECTORY}/earth`,
         position: {
           x: 50,
           y: 50,
@@ -253,7 +272,7 @@ import ImageGrid from '../../../components/ImageGrid';
 
     ```jsx
     overlays={[{
-      publicId: 'images/earth',
+      publicId: `images/earth`,
       position: {
         x: 10,
         y: 10,
@@ -280,7 +299,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       removeBackground
       underlay="images/galaxy"
     />
@@ -301,7 +320,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       removeBackground
       underlays={[
         {
@@ -365,7 +384,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="1335"
       height="891"
       src={`${process.env.EXAMPLES_DIRECTORY}/galaxy`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       blur="2000"
       brightness="300"
       text="Cool Beans"
@@ -382,7 +401,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="1335"
       height="891"
       src={`${process.env.EXAMPLES_DIRECTORY}/galaxy`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       blur="2000"
       brightness="300"
       overlays={[{
@@ -403,7 +422,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="1335"
       height="891"
       src={`${process.env.EXAMPLES_DIRECTORY}/sneakers`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       overlays={[{
         width: 2670 - 20,
         crop: 'fit',
@@ -458,7 +477,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       transformations={[
         'next-cloudinary-named-transformation'
       ]}
@@ -477,7 +496,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="100vw"
+      sizes="(max-width: 480px) 100vw, 50vw"
       rawTransformations={[
         'e_blur:2000',
         'e_tint:100:0000FF:0p:FF1493:100p'

--- a/docs/pages/guides/meta.json
+++ b/docs/pages/guides/meta.json
@@ -1,0 +1,3 @@
+{
+  "responsive-images": "Responsive Images"
+}

--- a/docs/pages/guides/responsive-images.mdx
+++ b/docs/pages/guides/responsive-images.mdx
@@ -1,0 +1,82 @@
+import Head from 'next/head';
+
+import OgImage from '../../components/OgImage';
+
+import { CldImage } from '../../../next-cloudinary';
+
+<Head>
+  <title>Responsive Images - Next Cloudinary</title>
+  <meta name="og:title" content="How Responsive Images Work in Next Cloudinary" />
+  <meta name="og:url" content={`https://next-cloudinary.spacejelly.dev/guides/responsive-images`} />
+</Head>
+
+<OgImage
+  title="Responsive Images"
+  twitterTitle="How Responsive Images Work in Next Cloudinary"
+/>
+
+# Responsive Images
+
+The [CldImage](/components/cldimage/basic-usage) component takes advantage of responsive images generated using the [Next Image component](https://nextjs.org/docs/api-reference/next/image).
+
+Using the `sizes` prop, you can configure exactly the sizes you need for your application, such as a similar example to the Next.js docs:
+
+
+```
+<CldImage
+  ...
+  sizes="(max-width: 768px) 100vw,
+          (max-width: 1200px) 50vw,
+          33vw"
+```
+
+Which would give you roughly full width images on mobile, a 2-column layout on tablets, and 3-column layout on desktop views.
+
+To ensure that the responsive images can effectively determine all appropriate sizes for the images, use the actual image width and height when specifying the dimension props.
+
+### Responsive Images & CldImage
+
+The only caveat to this is when using cropping modes in Cloudinary.
+
+In an example such as:
+
+```
+<CldImage
+  ...
+  width="600"
+  height="600"
+  sizes="(max-width: 480px) 100vw, 50vw"
+  crop="thumb"
+  gravity="faces"
+/>
+```
+
+Using cropping, we're setting a width of 600px and a height of 600px, telling Cloudinary we want to take our original image, crop it to that size, then position the focal point to the face in the image detected using AI.
+
+From a responsive standpoint, we're stating that we want full width images on anything less than 480px and half-width images on anything above.
+
+The challenge here is when cropping the image, we're cropping it to 600px, which is smaller than some of the sizes we want to responsively serve. We don't want to responsively change that cropped size, otherwise we would change the cropping results due to the crop attempting to grab different portions of the image depending on the size.
+
+To avoid attempting to load upscaled images, resulting in blurry or grainy images as well as more bandwidth used on a device, any responsive size that is greater than the set width will not be generated and instead, we'll deliver an image at the size specifiy (in this example, 600x600).
+
+For instance, in the above, the resulting responive image in the HTML may look like:
+
+```
+<img
+  sizes="(max-width: 480px) 100vw, 50vw"
+  srcset="
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/c_scale,w_384/f_auto/q_auto/v1/images/woman-headphones 384w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 640w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 750w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 828w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 1080w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 1200w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 1920w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 2048w,
+    https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_thumb,w_600,h_600,g_faces/f_auto/q_auto/v1/images/woman-headphones 3840w
+  " ... />
+```
+
+Notice that all of the URLs are the same except for the first one, as it's smaller than 600px.
+
+When the browser attempts to load these responsive images, it will effectively ignore the same URLs, only having loaded it once if resizing the browser.

--- a/docs/pages/meta.json
+++ b/docs/pages/meta.json
@@ -2,5 +2,6 @@
   "index": "Getting Started",
   "installation": "Installation",
   "components": "Components",
-  "use-cases": "Use Cases"
+  "use-cases": "Use Cases",
+  "guides": "Guides"
 }

--- a/docs/pages/use-cases/social-media-card.mdx
+++ b/docs/pages/use-cases/social-media-card.mdx
@@ -3,7 +3,7 @@ import Callout from 'nextra-theme-docs/callout';
 
 import OgImage from '../../components/OgImage';
 
-import { CldImage } from '../../../next-cloudinary';
+import { CldImage, CldOgImage } from '../../../next-cloudinary';
 
 <Head>
   <title>Social Media Cards - Next Cloudinary</title>
@@ -30,6 +30,7 @@ import { CldImage } from '../../../next-cloudinary';
   crop="fill"
   gravity="auto"
   src={`${process.env.EXAMPLES_DIRECTORY}/white`}
+  sizes="100w"
   overlays={[
     {
       publicId: 'images/mountain',
@@ -42,39 +43,39 @@ import { CldImage } from '../../../next-cloudinary';
         {
           crop: 'fill',
           gravity: 'auto',
-          width: 1280,
-          height: 1920
+          width: 800,
+          height: 1200
         }
       ]
     },
     {
-      width: 2240,
+      width: 1400,
       crop: 'fit',
       text: {
         color: 'black',
         fontFamily: 'Source Sans Pro',
-        fontSize: 240,
+        fontSize: 160,
         fontWeight: 'bold',
         text: 'Next Cloudinary'
       },
       position: {
         x: 100,
-        y: -140,
+        y: -100,
         gravity: 'west',
       },
     },
     {
-      width: 2240,
+      width: 1400,
       crop: 'fit',
       text: {
         color: 'black',
         fontFamily: 'Source Sans Pro',
-        fontSize: 128,
+        fontSize: 80,
         text: 'Get the power of Cloudinary in a Next.js project with Next Cloudinary!'
       },
       position: {
         x: 100,
-        y: 140,
+        y: 100,
         gravity: 'west',
       },
     },
@@ -108,7 +109,7 @@ import { CldImage } from '../../../next-cloudinary';
       text: {
         color: 'black',
         fontFamily: 'Source Sans Pro',
-        fontSize: 150,
+        fontSize: 160,
         fontWeight: 'bold',
         text: 'Next Cloudinary'
       },

--- a/docs/pages/use-cases/text-overlays.mdx
+++ b/docs/pages/use-cases/text-overlays.mdx
@@ -38,7 +38,7 @@ You can add text on top of your image with text-based overlays.
     text: {
       color: 'blueviolet',
       fontFamily: 'Source Sans Pro',
-      fontSize: 250,
+      fontSize: 160,
       fontWeight: 'bold',
       textDecoration: 'underline',
       letterSpacing: 14,
@@ -65,7 +65,7 @@ You can add text on top of your image with text-based overlays.
     text: {
       color: 'blueviolet',
       fontFamily: 'Source Sans Pro',
-      fontSize: 250,
+      fontSize: 160,
       fontWeight: 'bold',
       textDecoration: 'underline',
       letterSpacing: 14,

--- a/docs/pages/use-cases/uploading-images-and-videos.mdx
+++ b/docs/pages/use-cases/uploading-images-and-videos.mdx
@@ -28,7 +28,6 @@ The components utilize the [Cloudinary Upload Widget](https://cloudinary.com/doc
 
 export const SignedUpload = () => {
   const [resource, setResource] = useState();
-  console.log('resource', resource)
   return (
     <>
       <CldUploadButton

--- a/next-cloudinary/src/lib/cloudinary.js
+++ b/next-cloudinary/src/lib/cloudinary.js
@@ -65,7 +65,18 @@ export function constructCloudinaryUrl({ options, config }) {
     if ( pluginOptions?.format ) {
       options.format = pluginOptions.format;
     }
+
+    if ( pluginOptions?.width ) {
+      options.resize = {
+        width: pluginOptions?.width
+      };
+    }
   });
+
+  if ( options.resize ) {
+    const { width, crop = 'scale' } = options.resize;
+    cldImage.effect(`c_${crop},w_${width}`);
+  }
 
   return cldImage
           .setDeliveryType(options.deliveryType || 'upload')

--- a/next-cloudinary/src/loaders/cloudinary-loader.js
+++ b/next-cloudinary/src/loaders/cloudinary-loader.js
@@ -6,6 +6,9 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
     ...cldOptions
   }
 
+  options.width = parseInt(options.width);
+  options.height = parseInt(options.height);
+
   // The loader options are used to create dynamic sizing when working with responsive images
   // so these should override the default options collected from the props alone if
   // the results are different. While we don't always use the height in the loader logic,
@@ -13,8 +16,8 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
 
   if ( loaderOptions?.width && loaderOptions.width !== options.width ) {
     const multiplier = loaderOptions.width / options.width;
-    options.width = loaderOptions.width;
-    options.height = Math.round(options.height * multiplier);
+    options.widthResize = loaderOptions.width;
+    options.heightResize = Math.round(options.height * multiplier);
   }
 
   return constructCloudinaryUrl({

--- a/next-cloudinary/src/plugins/cropping.js
+++ b/next-cloudinary/src/plugins/cropping.js
@@ -1,9 +1,16 @@
 const cropsGravityAuto = [ 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
+const cropsWithZoom = ['crop', 'thumb'];
 
-export const props = ['crop', 'gravity'];
+export const props = [
+  'crop',
+  'gravity',
+  'zoom'
+];
 
 export function plugin({ cldImage, options } = {}) {
-  const { width, height, crop = 'limit' } = options;
+  const overrides = {};
+
+  const { width, height, widthResize, heightResize, crop = 'limit' } = options;
 
   let transformationString = `c_${crop},w_${width}`;
 
@@ -17,11 +24,31 @@ export function plugin({ cldImage, options } = {}) {
 
   if ( options.gravity ) {
     if ( options.gravity === 'auto' && !cropsGravityAuto.includes(crop) ) {
-      console.warn('Auto gravity can only be used with crop, fill, lfill, fill_pad or thumb. Not applying gravity.');
+      console.warn(`Auto gravity can only be used with crop modes: ${cropsGravityAuto.join(', ')}. Not applying gravity.`);
     } else {
       transformationString = `${transformationString},g_${options.gravity}`;
     }
   }
 
-  cldImage.resize(transformationString);
+  if ( options.zoom ) {
+    if ( options.zoom === 'auto' && !cropsWithZoom.includes(crop) ) {
+      console.warn(`Zoom can only be used with crop modes: ${cropsWithZoom.join(', ')}. Not applying zoom.`);
+    } else {
+      transformationString = `${transformationString},z_${options.zoom}`;
+    }
+  }
+
+  cldImage.effect(transformationString);
+
+  // If we have a resize width that's smaller than the user-defined width, we want to give the
+  // ability to perform a final resize on the image without impacting any of the effects like text
+  // overlays that may depend on the size to work properly
+
+  if ( typeof widthResize === 'number' && widthResize < width ) {
+    overrides.width = widthResize;
+  }
+
+  return {
+    options: overrides
+  }
 }

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -80,7 +80,32 @@ describe('Cloudinary Loader', () => {
       expect(result).toBe('https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_960/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
     });
 
-    it('should return a responsive images with loader options different from props', async () => {
+    it('should return responsive images', async () => {
+      const imageProps = {
+        height: '2724',
+        sizes: '100vw',
+        src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg',
+        width: '4096',
+        deliveryType: 'fetch'
+      }
+
+      const cldOptions = {};
+
+      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
+      const loaderOptions1 = { width: 2048 };
+      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
+      expect(result1).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_scale,w_${loaderOptions1.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions2 = { width: 3840 };
+      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
+      expect(result2).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_scale,w_${loaderOptions2.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions3 = { width: 640 };
+      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
+      expect(result3).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+    });
+
+    it('should return responsive images without upscaling for smaller images', async () => {
       const imageProps = {
         height: '600',
         sizes: '100vw',
@@ -91,17 +116,22 @@ describe('Cloudinary Loader', () => {
 
       const cldOptions = {};
 
-      const result1 = cloudinaryLoader({ loaderOptions: { width: 2048 }, imageProps, cldOptions, cldConfig });
-      expect(result1).toBe('https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_2048/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
+      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
 
-      const result2 = cloudinaryLoader({ loaderOptions: { width: 3840 }, imageProps, cldOptions, cldConfig });
-      expect(result2).toBe('https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_3840/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
+      const loaderOptions1 = { width: 2048 };
+      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
+      expect(result1).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
-      const result3 = cloudinaryLoader({ loaderOptions: { width: 640 }, imageProps, cldOptions, cldConfig });
-      expect(result3).toBe('https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_640/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
+      const loaderOptions2 = { width: 3840 };
+      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
+      expect(result2).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions3 = { width: 640 };
+      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
+      expect(result3).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_limit,w_${imageProps.width}/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
-    it('should return a responsive images with height when crop is not limit', async () => {
+    it('should return a responsive images with height when crop is not limit without upscaling', async () => {
       const imageProps = {
         height: '600',
         sizes: '100vw',
@@ -114,14 +144,54 @@ describe('Cloudinary Loader', () => {
         crop: 'fill'
       };
 
-      const result1 = cloudinaryLoader({ loaderOptions: { width: 2048 }, imageProps, cldOptions, cldConfig });
-      expect(result1).toBe('https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_2048,h_1280,g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
+      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
 
-      const result2 = cloudinaryLoader({ loaderOptions: { width: 3840 }, imageProps, cldOptions, cldConfig });
-      expect(result2).toBe('https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_3840,h_2400,g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
+      const loaderOptions1 = { width: 2048 };
+      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
+      expect(result1).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
-      const result3 = cloudinaryLoader({ loaderOptions: { width: 640 }, imageProps, cldOptions, cldConfig });
-      expect(result3).toBe('https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_640,h_400,g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg')
+      const loaderOptions2 = { width: 3840 };
+      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
+      expect(result2).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions3 = { width: 640 };
+      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
+      expect(result3).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+    });
+
+    it('should add any resizing after any effects are added', async () => {
+      const imageProps = {
+        height: '600',
+        sizes: '100vw',
+        src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg',
+        width: '960',
+        deliveryType: 'fetch',
+      }
+
+      const cldOptions = {
+        crop: 'fill',
+        overlays: [{
+          url: 'https://user-images.githubusercontent.com/1045274/199872380-ced2b84d-fce4-4fc9-9e76-48cb4a7fb35f.png'
+        }]
+      };
+
+      const urlBufer = Buffer.from(cldOptions.overlays[0].url);
+      const urlBase64 = urlBufer.toString('base64');
+      const urlParam = encodeURIComponent(urlBase64);
+
+      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
+
+      const loaderOptions1 = { width: 2048 };
+      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
+      expect(result1).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam},/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions2 = { width: 3840 };
+      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
+      expect(result2).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam},/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+
+      const loaderOptions3 = { width: 640 };
+      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
+      expect(result3).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam},/fl_layer_apply,fl_no_overflow/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
   })
 });

--- a/next-cloudinary/tests/plugins/cropping.spec.js
+++ b/next-cloudinary/tests/plugins/cropping.spec.js
@@ -35,4 +35,16 @@ describe('Cropping plugin', () => {
     plugin({ cldImage, options });
     expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto/${TEST_PUBLIC_ID}`);
   });
+
+  it('should apply a zoom if set explicitly', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 100,
+      height: 100,
+      crop: 'fill',
+      zoom: 0.5
+    };
+    plugin({ cldImage, options });
+    expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}/${TEST_PUBLIC_ID}`);
+  });
 });


### PR DESCRIPTION
# Description

Adds the ability to use the zoom prop when using crop modes crop and thumb.

This additionally fixes /  corrects an issue where the responsive generation would add the sizes to the image URLs, upscaling the images unnecessarily, which adds more page load unnecessarily and creates inconsistencies with overlays with different sizes. The result is that the width/height must or should be set to the image's actual width/height to allow the generation to properly resize.

## Issue Ticket Number

Fixes #70

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
