### PR TITLE
Overlay Effects, Add Opacity

### DIFF
--- a/docs/pages/components/cldimage/configuration.mdx
+++ b/docs/pages/components/cldimage/configuration.mdx
@@ -66,6 +66,7 @@ import OgImage from '../../../components/OgImage';
 | improve            | bool/string | `true`, `"50"`, `"indoor"`                           |
 | negate             | bool        | `true`                                               |
 | oilPaint           | bool/string | `true`, `"40"`                                       |
+| opacity            | number/string | `40`, `"40"`                                       |
 | outline            | bool/string | `true`, `"40"`, `"outer:15:200"`                     |
 | pixelate           | bool/string | `true`, `"20"`                                       |
 | pixelateFaces      | bool/string | `true`, `"20"`                                       |
@@ -107,7 +108,7 @@ The position property can include:
 | x             | number | `10`           |
 | y             | number | `10`           |
 
-Objects in the effects array can include:
+Objects in the effects array can include everything in the effects options above as well as:
 
 | Property Name | Type   | Example        |
 | ------------- | ------ | -------------- |

--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -29,6 +29,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       removeBackground
+      alt="Background Removal"
     />
 
     ### Background Removal
@@ -48,6 +49,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       zoompan="loop"
+      alt="Zoom &amp; Pan"
     />
 
     ### Zoom &amp; Pan
@@ -63,6 +65,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       blur="1200"
+      alt="Blur"
     />
 
     ### Blur
@@ -78,6 +81,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       pixelate
+      alt="Pixelate"
     />
 
     ### Pixelate
@@ -93,6 +97,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       grayscale
+      alt="Grayscale"
     />
 
     ### Grayscale
@@ -108,12 +113,43 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       tint="equalize:80:blue:blueviolet"
+      alt="Tint"
     />
 
     ### Tint
 
     ```jsx
     tint="equalize:80:blue:blueviolet"
+    ```
+  </li>
+  <li>
+    <CldImage
+      width="960"
+      height="600"
+      src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
+      opacity="50"
+      alt="Opacity"
+    />
+
+    ### Opacity
+
+    ```jsx
+    opacity="50"
+    ```
+  </li>
+  <li>
+    <CldImage
+      width="960"
+      height="600"
+      src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
+      shear="40:0"
+      alt="Shear"
+    />
+
+    ### Shear
+
+    ```jsx
+    shear="40:0"
     ```
   </li>
 </ImageGrid>
@@ -131,6 +167,7 @@ import ImageGrid from '../../../components/ImageGrid';
       sizes="(max-width: 480px) 100vw, 50vw"
       crop="thumb"
       gravity="auto"
+      alt="Original"
     />
 
     ### Original
@@ -144,6 +181,7 @@ import ImageGrid from '../../../components/ImageGrid';
       sizes="(max-width: 480px) 100vw, 50vw"
       crop="thumb"
       gravity="auto"
+      alt="Thumbnail with Auto Gravity"
     />
 
     ### Thumbnail with Auto Gravity
@@ -161,6 +199,7 @@ import ImageGrid from '../../../components/ImageGrid';
       sizes="(max-width: 480px) 100vw, 50vw"
       crop="thumb"
       gravity="faces"
+      alt="Thumbnail with Faces Gravity"
     />
 
     ### Thumbnail with Faces Gravity
@@ -179,6 +218,7 @@ import ImageGrid from '../../../components/ImageGrid';
       crop="thumb"
       gravity="faces"
       zoom="0.5"
+      alt="Thumbnail with Faces Gravity and Zoom"
     />
 
     ### Thumbnail with Faces Gravity and Zoom
@@ -201,6 +241,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       placeholder="blur"
+      alt="Blur"
     />
 
     ### Blur
@@ -216,6 +257,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       placeholder="grayscale"
+      alt="Grayscale"
     />
 
     ### Grayscale
@@ -231,6 +273,7 @@ import ImageGrid from '../../../components/ImageGrid';
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
       sizes="(max-width: 480px) 100vw, 50vw"
       placeholder="color:blueviolet"
+      alt="Color"
     />
 
     ### Color
@@ -266,6 +309,7 @@ import ImageGrid from '../../../components/ImageGrid';
           }
         ]
       }]}
+      alt="Overlay Image by Public ID"
     />
 
     ### Overlay Image by Public ID
@@ -302,6 +346,7 @@ import ImageGrid from '../../../components/ImageGrid';
       sizes="(max-width: 480px) 100vw, 50vw"
       removeBackground
       underlay="images/galaxy"
+      alt="Background Removal with Underlay by Public ID"
     />
 
     ### Background Removal with Underlay by Public ID
@@ -342,6 +387,7 @@ import ImageGrid from '../../../components/ImageGrid';
           }
         },
       ]}
+      alt="Background Removal with Multiple Underlays"
     />
 
     ### Background Removal with Multiple Underlays
@@ -388,6 +434,7 @@ import ImageGrid from '../../../components/ImageGrid';
       blur="2000"
       brightness="300"
       text="Cool Beans"
+      alt="Text Overlay with text prop"
     />
 
     ### Text Overlay with text prop
@@ -407,6 +454,7 @@ import ImageGrid from '../../../components/ImageGrid';
       overlays={[{
         text: 'Cool Beans'
       }]}
+      alt="Text Overlay with text string"
     />
 
     ### Text Overlay with text string
@@ -442,6 +490,7 @@ import ImageGrid from '../../../components/ImageGrid';
           text: 'Cool Beans'
         }
       }]}
+      alt="Text Overlay with overlay configuration"
     />
 
     ### Text Overlay with overlay configuration
@@ -467,6 +516,50 @@ import ImageGrid from '../../../components/ImageGrid';
     }]}
     ```
   </li>
+  <li>
+    <CldImage
+      width="1335"
+      height="891"
+      src={`${process.env.EXAMPLES_DIRECTORY}/galaxy`}
+      sizes="(max-width: 480px) 100vw, 50vw"
+      overlays={[{
+        text: {
+          color: 'white',
+          fontFamily: 'Source Sans Pro',
+          fontSize: 160,
+          fontWeight: 'bold',
+          text: 'Cool Beans'
+        },
+        effects: [
+          {
+            shear: '40:0',
+            opacity: 50
+          }
+        ]
+      }]}
+      alt="Text Overlay with Effects"
+    />
+
+    ### Text Overlay with Effects
+
+    ```jsx
+    overlays={[{
+      text: {
+        color: 'white',
+        fontFamily: 'Source Sans Pro',
+        fontSize: 160,
+        fontWeight: 'bold',
+        text: 'Cool Beans'
+      },
+      effects: [
+        {
+          shear: '40:0',
+          opacity: 50
+        }
+      ]
+    }]}
+    ```
+  </li>
 </ImageGrid>
 
 ## Other
@@ -481,6 +574,7 @@ import ImageGrid from '../../../components/ImageGrid';
       transformations={[
         'next-cloudinary-named-transformation'
       ]}
+      alt="Named Transformations"
     />
 
     ### Named Transformations
@@ -501,6 +595,7 @@ import ImageGrid from '../../../components/ImageGrid';
         'e_blur:2000',
         'e_tint:100:0000FF:0p:FF1493:100p'
       ]}
+      alt="Raw Transformations"
     />
 
     ### Raw Transformations
@@ -521,6 +616,7 @@ import ImageGrid from '../../../components/ImageGrid';
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/c_fill,h_300,w_250/e_blur:300/turtle`}
       preserveTransformations
+      alt="Preserve Transformations"
     />
   </li>
 </ImageGrid>

--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -6,7 +6,8 @@ import { cloudinaryLoader } from '../../loaders/cloudinary-loader';
 
 const CldImage = props => {
   const CLD_OPTIONS = [
-    'deliveryType'
+    'deliveryType',
+    'preserveTransformations'
   ];
 
   transformationPlugins.forEach(({ props = [] }) => {
@@ -62,7 +63,7 @@ const CldImage = props => {
   }
 
   if (props.src && props.preserveTransformations) {
-    const transformations = getTransformations(props.src,props.preserveTransformations);
+    const transformations = getTransformations(props.src, props.preserveTransformations);
     imageProps.rawTransformations = [...imageProps.rawTransformations,...transformations,];
   }
 

--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -6,8 +6,7 @@ import { cloudinaryLoader } from '../../loaders/cloudinary-loader';
 
 const CldImage = props => {
   const CLD_OPTIONS = [
-    'deliveryType',
-    'preserveTransformations'
+    'deliveryType'
   ];
 
   transformationPlugins.forEach(({ props = [] }) => {
@@ -63,7 +62,7 @@ const CldImage = props => {
   }
 
   if (props.src && props.preserveTransformations) {
-    const transformations = getTransformations(props.src, props.preserveTransformations);
+    const transformations = getTransformations(props.src,props.preserveTransformations);
     imageProps.rawTransformations = [...imageProps.rawTransformations,...transformations,];
   }
 

--- a/next-cloudinary/src/constants/qualifiers.js
+++ b/next-cloudinary/src/constants/qualifiers.js
@@ -67,3 +67,165 @@ export const text = {
     qualifier: false
   }
 }
+
+export const effects = {
+  art: {
+    prefix: 'e',
+    qualifier: 'art',
+  },
+  autoBrightness: {
+    prefix: 'e',
+    qualifier: 'auto_brightness',
+  },
+  autoColor: {
+    prefix: 'e',
+    qualifier: 'auto_color',
+  },
+  autoContrast: {
+    prefix: 'e',
+    qualifier: 'auto_contrast',
+  },
+  assistColorblind: {
+    prefix: 'e',
+    qualifier: 'assist_colorblind',
+  },
+  blackwhite: {
+    prefix: 'e',
+    qualifier: 'blackwhite',
+  },
+  blur: {
+    prefix: 'e',
+    qualifier: 'blur',
+  },
+  blurFaces: {
+    prefix: 'e',
+    qualifier: 'blur_faces',
+  },
+  blurRegion: {
+    prefix: 'e',
+    qualifier: 'blur_region',
+  },
+  brightness: {
+    prefix: 'e',
+    qualifier: 'brightness',
+  },
+  brightnessHSB: {
+    prefix: 'e',
+    qualifier: 'brightness_hsb',
+  },
+  cartoonify: {
+    prefix: 'e',
+    qualifier: 'cartoonify',
+  },
+  colorize: {
+    prefix: 'e',
+    qualifier: 'colorize',
+  },
+  contrast: {
+    prefix: 'e',
+    qualifier: 'contrast',
+  },
+  distort: {
+    prefix: 'e',
+    qualifier: 'distort',
+  },
+  fillLight: {
+    prefix: 'e',
+    qualifier: 'fill_light',
+  },
+  gamma: {
+    prefix: 'e',
+    qualifier: 'gamma',
+  },
+  gradientFade: {
+    prefix: 'e',
+    qualifier: 'gradient_fade',
+  },
+  grayscale: {
+    prefix: 'e',
+    qualifier: 'grayscale',
+  },
+  improve: {
+    prefix: 'e',
+    qualifier: 'improve',
+  },
+  negate: {
+    prefix: 'e',
+    qualifier: 'negate',
+  },
+  oilPaint: {
+    prefix: 'e',
+    qualifier: 'oil_paint',
+  },
+  opacity: {
+    qualifier: 'o'
+  },
+  outline: {
+    prefix: 'e',
+    qualifier: 'outline',
+  },
+  pixelate: {
+    prefix: 'e',
+    qualifier: 'pixelate',
+  },
+  pixelateFaces: {
+    prefix: 'e',
+    qualifier: 'pixelate_faces',
+  },
+  pixelateRegion: {
+    prefix: 'e',
+    qualifier: 'pixelate_region',
+  },
+  redeye: {
+    prefix: 'e',
+    qualifier: 'redeye',
+  },
+  replaceColor: {
+    prefix: 'e',
+    qualifier: 'replace_color',
+  },
+  saturation: {
+    prefix: 'e',
+    qualifier: 'saturation',
+  },
+  sepia: {
+    prefix: 'e',
+    qualifier: 'sepia',
+  },
+  shadow: {
+    prefix: 'e',
+    qualifier: 'shadow',
+  },
+  sharpen: {
+    prefix: 'e',
+    qualifier: 'sharpen',
+  },
+  shear: {
+    prefix: 'e',
+    qualifier: 'shear',
+  },
+  simulateColorblind: {
+    prefix: 'e',
+    qualifier: 'simulate_colorblind',
+  },
+  tint: {
+    prefix: 'e',
+    qualifier: 'tint',
+  },
+  unsharpMask: {
+    prefix: 'e',
+    qualifier: 'unsharp_mask',
+  },
+  vectorize: {
+    prefix: 'e',
+    qualifier: 'vectorize',
+  },
+  vibrance: {
+    prefix: 'e',
+    qualifier: 'vibrance',
+  },
+  vignette: {
+    prefix: 'e',
+    qualifier: 'vignette',
+  },
+}

--- a/next-cloudinary/src/plugins/effects.js
+++ b/next-cloudinary/src/plugins/effects.js
@@ -1,101 +1,24 @@
-const params = [
-  'art',
-  {
-    prop: 'autoBrightness',
-    effect: 'auto_brightness',
-  },
-  {
-    prop: 'autoColor',
-    effect: 'auto_color',
-  },
-  {
-    prop: 'autoContrast',
-    effect: 'auto_contrast',
-  },
-  {
-    prop: 'assistColorblind',
-    effect: 'assist_colorblind',
-  },
-  'blackwhite',
-  'blur',
-  {
-    prop: 'blurFaces',
-    effect: 'blur_faces',
-  },
-  {
-    prop: 'blurRegion',
-    effect: 'blur_region',
-  },
-  'brightness',
-  {
-    prop: 'brightnessHSB',
-    effect: 'brightness_hsb',
-  },
-  'cartoonify',
-  'colorize',
-  'contrast',
-  'distort',
-  {
-    prop: 'fillLight',
-    effect: 'fill_light',
-  },
-  'gamma',
-  {
-    prop: 'gradientFade',
-    effect: 'gradient_fade',
-  },
-  'grayscale',
-  'improve',
-  'negate',
-  {
-    prop: 'oilPaint',
-    effect: 'oil_paint',
-  },
-  'outline',
-  'pixelate',
-  {
-    prop: 'pixelateFaces',
-    effect: 'pixelate_faces',
-  },
-  {
-    prop: 'pixelateRegion',
-    effect: 'pixelate_region',
-  },
-  'redeye',
-  {
-    prop: 'replaceColor',
-    effect: 'replace_color',
-  },
-  'saturation',
-  'sepia',
-  'shadow',
-  'sharpen',
-  'shear',
-  {
-    prop: 'simulateColorblind',
-    effect: 'simulate_colorblind',
-  },
-  'tint',
-  {
-    prop: 'unsharpMask',
-    effect: 'unsharp_mask',
-  },
-  'vectorize',
-  'vibrance',
-  'vignette',
-];
+import { effects } from '../constants/qualifiers';
 
-export const props = params.map(param => param.prop || param);
+export const props = Object.keys(effects);
 
 export function plugin({ cldImage, options } = {}) {
-  params.forEach(key => {
-    const prop = key.prop || key;
-    const effect = key.effect || key;
+  Object.keys(effects).forEach(key => {
+    const { prefix, qualifier } = effects[key];
+    let transformation = '';
 
-    if ( options[prop] === true ) {
-      cldImage.effect(`e_${effect}`);
-    } else if ( typeof options[prop] === 'string' ) {
-      cldImage.effect(`e_${effect}:${options[prop]}`);
+    if ( prefix ) {
+      transformation = `${prefix}_`;
+    }
+
+    if ( options[key] === true ) {
+      cldImage.effect(`${transformation}${qualifier}`);
+    } else if ( typeof options[key] === 'string' ) {
+      if ( prefix ) {
+        cldImage.effect(`${transformation}${qualifier}:${options[key]}`);
+      } else {
+        cldImage.effect(`${qualifier}_${options[key]}`);
+      }
     }
   });
 }

--- a/next-cloudinary/src/plugins/overlays.js
+++ b/next-cloudinary/src/plugins/overlays.js
@@ -1,9 +1,10 @@
 import { encodeBase64 } from '../lib/util';
 
 import {
+  effects as qualifiersEffects,
+  position as qualifiersPosition,
   primary as qualifiersPrimary,
   text as qualifiersText,
-  position as qualifiersPosition
 } from '../constants/qualifiers';
 
 export const props = ['text', 'overlays'];
@@ -86,12 +87,33 @@ export function plugin({ cldImage, options } = {}) {
     });
 
     // Layer effects
+    // For layer effects we allow both the standard effects to be applied as well
+    // as the primary ones like width and height as those can be used to modify
+    // the layer after it's created
 
     layerEffects.forEach(effect => {
       Object.keys(effect).forEach(key => {
-        if ( !qualifiersPrimary[key] ) return;
-        const { qualifier } = qualifiersPrimary[key];
-        primary.push(`${qualifier}_${effect[key]}`);
+        if ( qualifiersPrimary[key] ) {
+          const { qualifier } = qualifiersPrimary[key];
+          primary.push(`${qualifier}_${effect[key]}`);
+        } else if ( qualifiersEffects[key] ) {
+          const { qualifier, prefix } = qualifiersEffects[key];
+          let transformation = '';
+
+          if ( prefix ) {
+            transformation = `${prefix}_`;
+          }
+
+          if ( effect[key] === true ) {
+            primary.push(`${transformation}${qualifier}`);
+          } else if ( typeof effect[key] === 'string' || typeof effect[key] === 'number' ) {
+            if ( prefix ) {
+              primary.push(`${transformation}${qualifier}:${effect[key]}`);
+            } else {
+              primary.push(`${qualifier}_${effect[key]}`);
+            }
+          }
+        }
       });
     });
 

--- a/next-cloudinary/tests/plugins/overlays.spec.js
+++ b/next-cloudinary/tests/plugins/overlays.spec.js
@@ -32,6 +32,39 @@ describe('Plugins', () => {
       expect(cldImage.toURL()).toContain(`l_fetch:aHR0cHM6Ly91c2VyLWltYWdlcy5naXRodWJ1c2VyY29udGVudC5jb20vMTA0NTI3NC8xOTk4NzIzODAtY2VkMmI4NGQtZmNlNC00ZmM5LTllNzYtNDhjYjRhN2ZiMzVmLnBuZw%3D%3D`);
     });
 
+    it('should apply effects to an overlay by public ID', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const publicId = 'images/my-cool-image'
+      const width = 100;
+      const height = 200;
+      const shear = '40:0';
+      const opacity = '50';
+
+      const options = {
+        overlays: [{
+          publicId,
+          effects: [
+            {
+              width,
+              height,
+            },
+            {
+              shear,
+              opacity,
+            }
+          ]
+        }]
+      }
+
+      plugin({
+        cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`l_${publicId.replace(/\//g, ':')},w_${width},h_${height},e_shear:${shear},o_${opacity}/fl_layer_apply,fl_no_overflow`);
+    });
+
   })
   describe('Text Overlays', () => {
     it('should add a text overlay configured by overlay object', () => {


### PR DESCRIPTION
# Description

This allows overlays to now use any of the effects in the overlay effects array, such as:

```
overlays={[
  {
    ...,
    effects: {
      shear: '40:0'
    }
  }
]}
```

It also adds opacity as an available option both as a top level prop and as an effect.

## Issue Ticket Number

Fixes #80 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
