### PR TITLE
Fixes Extra Comma in Overlay Transformation

### DIFF
--- a/next-cloudinary/src/plugins/overlays.js
+++ b/next-cloudinary/src/plugins/overlays.js
@@ -182,7 +182,9 @@ export function plugin({ cldImage, options } = {}) {
 
     // Add all primary transformations
 
-    layerTransformation = `${layerTransformation},${primary.join(',')}`;
+    if ( primary.length > 0 ) {
+      layerTransformation = `${layerTransformation},${primary.join(',')}`;
+    }
 
     // Add all applied transformations
 

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -183,15 +183,15 @@ describe('Cloudinary Loader', () => {
 
       const loaderOptions1 = { width: 2048 };
       const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
-      expect(result1).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam},/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result1).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions2 = { width: 3840 };
       const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
-      expect(result2).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam},/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result2).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
 
       const loaderOptions3 = { width: 640 };
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
-      expect(result3).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam},/fl_layer_apply,fl_no_overflow/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
+      expect(result3).toBe(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
   })
 });

--- a/next-cloudinary/tests/plugins/overlays.spec.js
+++ b/next-cloudinary/tests/plugins/overlays.spec.js
@@ -36,6 +36,25 @@ describe('Plugins', () => {
       const cldImage = cld.image(TEST_PUBLIC_ID);
 
       const publicId = 'images/my-cool-image'
+
+      const options = {
+        overlays: [{
+          publicId
+        }]
+      }
+
+      plugin({
+        cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`l_${publicId.replace(/\//g, ':')}/fl_layer_apply,fl_no_overflow`);
+    });
+
+    it('should apply effects to an overlay', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const publicId = 'images/my-cool-image'
       const width = 100;
       const height = 200;
       const shear = '40:0';


### PR DESCRIPTION
# Description

When adding an overlay by public ID with no additional effects, an extra comma is added `,` due to the `primary` transformations trying to be applied when they don't exist.

While it seems harmless it prevents some images from working as overlays, causing issues.

## Issue Ticket Number

Fixes #87 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
