### PR TITLE
Added `'use client';` to CldImage component

### DIFF
--- a/next-cloudinary/src/components/CldImage/CldImage.js
+++ b/next-cloudinary/src/components/CldImage/CldImage.js
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import Image from 'next/image';
 


### PR DESCRIPTION
# Description

Added `'use client';` to CldImage component. This allows compatibility with NextJS 13's "app" directory feature which would otherwise try to SSR this component, throwing an error due to the use of `useState`.

## Issue Ticket Number

Fixes #97 

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
