### PR TITLE
Fixes Underlay Sizing

### DIFF
--- a/docs/pages/components/cldogimage/basic-usage.mdx
+++ b/docs/pages/components/cldogimage/basic-usage.mdx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { Callout } from 'nextra-theme-docs';
 
 import OgImage from '../../../components/OgImage';
 import Video from '../../../components/Video';
@@ -25,6 +26,13 @@ The basic required prop is `src`:
   src="images/turtle"
 />
 ```
+
+Place this anywhere outside of the Head component.
+
+<Callout emoji={false}>
+  The CldOgImage component must be placed outside of the Next.js Head component as the Head component does not accept React components as children.
+</Callout>
+
 
 The resulting HTML will be applied to the Head of the document:
 

--- a/next-cloudinary/src/constants/qualifiers.js
+++ b/next-cloudinary/src/constants/qualifiers.js
@@ -250,3 +250,11 @@ export const effects = {
     qualifier: 'vignette',
   },
 }
+
+export const flags = {
+  relative: {
+    prefix: 'fl',
+    qualifier: 'relative',
+    location: 'primary'
+  }
+}

--- a/next-cloudinary/src/plugins/underlays.js
+++ b/next-cloudinary/src/plugins/underlays.js
@@ -1,6 +1,6 @@
 import {
+  flags as qualifiersFlags,
   primary as qualifiersPrimary,
-  text as qualifiersText,
   position as qualifiersPosition
 } from '../constants/qualifiers';
 
@@ -20,15 +20,10 @@ export function plugin({ cldImage, options } = {}) {
 
     const underlayOptions = {
       publicId: underlay,
-      crop: 'fill'
-    }
-
-    if ( options.width ) {
-      underlayOptions.width = options.width;
-    }
-
-    if ( options.height ) {
-      underlayOptions.height = options.height;
+      crop: 'fill',
+      width: '1.0',
+      height: '1.0',
+      flags: ['relative']
     }
 
     applyUnderlay(underlayOptions);
@@ -38,7 +33,7 @@ export function plugin({ cldImage, options } = {}) {
    * applyUnderlay
    */
 
-  function applyUnderlay({ publicId, type, position, text, effects: layerEffects = [], ...options }) {
+  function applyUnderlay({ publicId, type, position, text, effects: layerEffects = [], flags = [], ...options }) {
     const hasPublicId = typeof publicId === 'string';
     const hasPosition = typeof position === 'object';
 
@@ -87,6 +82,16 @@ export function plugin({ cldImage, options } = {}) {
         applied.push(`${qualifier}_${position[key]}`);
       });
     }
+
+    // Positioning
+
+    flags.forEach(key => {
+      if ( !qualifiersFlags[key] ) return;
+
+      const { qualifier, prefix } = qualifiersFlags[key];
+
+      primary.push(`${prefix}_${qualifier}`);
+    });
 
     // Add all primary transformations
 

--- a/next-cloudinary/tests/plugins/underlays.spec.js
+++ b/next-cloudinary/tests/plugins/underlays.spec.js
@@ -43,8 +43,8 @@ describe('Plugins', () => {
       const cldImage = cld.image(TEST_PUBLIC_ID);
 
       const publicId = 'images/galaxy';
-      const width = 1920;
-      const height = 1200;
+      const width = '1.0';
+      const height = '1.0';
       const crop = 'fill';
 
       const options = {
@@ -56,7 +56,7 @@ describe('Plugins', () => {
         options
       });
 
-      expect(cldImage.toURL()).toContain(`u_${publicId.replace(/\//g, ':')},c_${crop}/fl_layer_apply,fl_no_overflow/${TEST_PUBLIC_ID}`);
+      expect(cldImage.toURL()).toContain(`u_${publicId.replace(/\//g, ':')},c_${crop},w_${width},h_${height},fl_relative/fl_layer_apply,fl_no_overflow/${TEST_PUBLIC_ID}`);
     });
   });
 });


### PR DESCRIPTION
# Description

Underlays using the `underlay` prop which provides some default options for easily filling a background would use the size of the CldImage width and height. IF this didn't match the image, this resulted in unexpected sizing in the background, potentially not filling it, even if it technically would be improper use of the width and height

this uses relative sizing so that it always fills based on the size of the image

## Issue Ticket Number

Fixes #100 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
