### PR TITLE
Make `tsc` directly emit typescript declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .vscode
 .env
 next-cloudinary/dist
+.idea
+tsconfig.tsbuildinfo

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -5,7 +5,6 @@
   "module": "dist/next-cloudinary.module.js",
   "umd:main": "dist/next-cloudinary.umd.js",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
   "scripts": {
     "build": "microbundle --no-compress --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react",
     "dev": "microbundle watch --no-compress --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react",

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -24,7 +24,8 @@ const CldOgImage = ({ excludeTags = [] as string[], twitterTitle, ...props }) =>
   // We need to include the tags within the Next.js Head component rather than
   // direcly adding them inside of the Head otherwise we get unexpected results
 
-  return (
+    return (
+    // @ts-ignore
     <Head>
       <meta property="og:image" content={ogImageUrl} />
       <meta property="og:image:secure_url" content={ogImageUrl} />

--- a/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
+++ b/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
@@ -11,6 +11,7 @@ const CldUploadButton = ({
 }) => {
   return (
     <>
+      {/*  @ts-ignore */}
       <CldUploadWidget
         onUpload={onUpload}
         options={options}

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -59,7 +59,6 @@ const CldUploadWidget = ({
       }
     }
 
-    // @ts-ignore
     return cloudinary.current?.createUploadWidget(
       uploadOptions,
       function (error, result) {
@@ -107,6 +106,7 @@ const CldUploadWidget = ({
       })}
       <Script
         id={`cloudinary-${Math.floor(Math.random() * 100)}`}
+        // @ts-ignore
         src="https://widget.cloudinary.com/v2.0/global/all.js"
         onLoad={handleOnLoad}
         onError={(e) => console.error(`Failed to load Cloudinary: ${e.message}`)}

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -8,7 +8,7 @@ const CldUploadWidget = ({
   signatureEndpoint,
   uploadPreset,
 }) => {
-  const cloudinary = useRef();
+  const cloudinary = useRef<any>();
   const widget = useRef();
 
   const signed = !!signatureEndpoint;
@@ -65,7 +65,7 @@ const CldUploadWidget = ({
         // The callback is a bit more chatty than failed or success so
         // only trigger when one of those are the case. You can additionally
         // create a separate handler such as onEvent and trigger it on
-        // ever occurance
+        // ever occurrence
         if (error || result.event === "success") {
           onUpload(error, result, widget?.current);
         }

--- a/next-cloudinary/tsconfig.json
+++ b/next-cloudinary/tsconfig.json
@@ -25,7 +25,6 @@
     "composite": true,
     "declaration": true,
     "declarationDir": "dist",
-    "emitDeclarationOnly": true,
   },
   "include": ["src/**/*"],
 }

--- a/next-cloudinary/tsconfig.json
+++ b/next-cloudinary/tsconfig.json
@@ -8,7 +8,6 @@
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
     "module": "esnext",
@@ -21,6 +20,12 @@
       {
         "name": "next"
       }
-    ]
-  }
+    ],
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "dist",
+    "emitDeclarationOnly": true,
+  },
+  "include": ["src/**/*"],
 }


### PR DESCRIPTION
# Description

microbundler/rollup were doing it wrong, by not emitting the `index.d.ts` files per component, but tsc directly creates the declarations correctly. The `tsconfig.json` now specifies that declarations need to be emitted by the typescript compiler and sticks them into the appropriate build folder.

<!-- Include a summary of the change made and also list the dependencies that are required if any -->

## Issue Ticket Number

Fixes #106 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
