### PR TITLE
Support fill=true by not applying a width if not set

### DIFF
--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -775,12 +775,22 @@ import ImageGrid from '../../../components/ImageGrid';
 ## Next Image Features
 
 <ImageGrid>
-  <li style={{ position: 'relative', height: '10em' }}>
-    <CldImage
-      src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      fill={true}
-      alt=""
-    />
+  <li>
+    <div style={{ position: 'relative', height: '10em' }}>
+      <CldImage
+        src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
+        fill={true}
+        alt=""
+      />
+    </div>
+
+    ### Fill
+
+    ```jsx
+    <div style={{ position: 'relative', height: '10em' }}>
+    ...
+    fill={true}
+    ```
   </li>
 </ImageGrid>
 

--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -772,6 +772,18 @@ import ImageGrid from '../../../components/ImageGrid';
   </li>
 </ImageGrid>
 
+## Next Image Features
+
+<ImageGrid>
+  <li style={{ position: 'relative', height: '10em' }}>
+    <CldImage
+      src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
+      fill={true}
+      alt=""
+    />
+  </li>
+</ImageGrid>
+
 ## Other
 
 <ImageGrid>

--- a/next-cloudinary/src/plugins/cropping.js
+++ b/next-cloudinary/src/plugins/cropping.js
@@ -10,9 +10,13 @@ export const props = [
 export function plugin({ cldImage, options } = {}) {
   const overrides = {};
 
-  const { width, height, widthResize, heightResize, crop = 'limit' } = options;
+  const { width, height, widthResize, crop = 'limit' } = options;
 
-  let transformationString = `c_${crop},w_${width}`;
+  let transformationString = '';
+
+  if ( width ) {
+    transformationString = `c_${crop},w_${width}`;
+  }
 
   if ( !options.gravity && cropsGravityAuto.includes(crop) ) {
     options.gravity = 'auto';

--- a/next-cloudinary/tests/plugins/cropping.spec.js
+++ b/next-cloudinary/tests/plugins/cropping.spec.js
@@ -47,4 +47,11 @@ describe('Cropping plugin', () => {
     plugin({ cldImage, options });
     expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}/${TEST_PUBLIC_ID}`);
   });
+
+  it('should not include a width if not set', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {};
+    plugin({ cldImage, options });
+    expect(cldImage.toURL()).toContain(`image/upload/${TEST_PUBLIC_ID}`);
+  });
 });


### PR DESCRIPTION
# Description

Next Image has a feature fill=true which allows the image to not specify a width or a height, but instead, you can use the parent container to control how it fits.

https://nextjs.org/docs/api-reference/next/image#fill

Currently when using that, Cloudinary doesn't see a width and ends up with w_NaN.

To avoid this, we're only setting the width if it's present in the tag.

## Issue Ticket Number

Fixes #110 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
