### PR TITLE
Fixes preserveTransformations

### DIFF
--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -822,11 +822,11 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.EXAMPLES_DIRECTORY}/turtle`}
-      sizes="(max-width: 480px) 100vw, 50vw"
       rawTransformations={[
         'e_blur:2000',
         'e_tint:100:0000FF:0p:FF1493:100p'
       ]}
+      sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
     />
 
@@ -839,16 +839,23 @@ import ImageGrid from '../../../components/ImageGrid';
     ]}
     ```
   </li>
-</ImageGrid>
-
-<ImageGrid>
   <li>
     <CldImage
       width="960"
       height="600"
-      src={`${process.env.EXAMPLES_DIRECTORY}/c_fill,h_300,w_250/e_blur:300/turtle`}
+      src={`https://res.cloudinary.com/${process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME}/image/upload/c_fill,h_300,w_250/e_blur:1000/v1/${process.env.EXAMPLES_DIRECTORY}/turtle`}
       preserveTransformations
+      tint="equalize:80:blue:blueviolet"
+      sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
     />
+
+    ### Preserve Transformations
+
+    ```jsx
+    src={`https://res.cloudinary.com/<Cloud Name>/image/upload/c_fill,h_300,w_250/e_blur:1000/v1/<Public ID>`}
+    preserveTransformations
+    tint="equalize:80:blue:blueviolet"
+    ```
   </li>
 </ImageGrid>

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@cloudinary-util/url-loader": "^1.2.4",
-    "@cloudinary-util/util": "^1.1.1",
+    "@cloudinary-util/util": "^1.2.0",
     "@cloudinary/url-gen": "^1.8.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,10 +1018,15 @@
     "@cloudinary-util/util" "1.1.1"
     "@cloudinary/url-gen" "^1.8.7"
 
-"@cloudinary-util/util@1.1.1", "@cloudinary-util/util@^1.1.1":
+"@cloudinary-util/util@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@cloudinary-util/util/-/util-1.1.1.tgz#29fe85c26acc710143044484f12332672ec520d0"
   integrity sha512-Yt7BobX2BsetzLNNtVl8Mo4qdt2XWoU7k3O1Y39kIaLLMX2/E6Heqc3FkXwGm3FRe/t6ZIk9ZR9ePGNcoEGPMw==
+
+"@cloudinary-util/util@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@cloudinary-util/util/-/util-1.2.0.tgz#4b6064ac9c1032bd1ef31f28f1524d552e1b021b"
+  integrity sha512-x4qzKuTUM2RfOFdhLZQfgipheWUmHrjd0b0KynjmhjPsBtJe1FKwHE4Mjze0JGYyOyHP5W8v9DMPpr8UQ61SEA==
 
 "@cloudinary/transformation-builder-sdk@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
# Description

preserveTransformations doesn't currently work when using it, this fixes it by updating getTransformations from Cloudinary Util and adding it to the beginning of a transformation chain.

Caveat here is that it gets parsed using parseUrl in the background which has trouble getting anything but the last set of transformations (ex my/transformation/chain) but works for a single set until the regex is resolved to get all of that somehow.

The URL also needs to have a version number in it, but that's also a requirement from passing in a cloudinary URL to begin with.

## Issue Ticket Number

Fixes #82 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
