### PR TITLE
Fix Handling CldUploadWidget Callback Updates to State

### DIFF
--- a/docs/pages/components/cldimage/basic-usage.mdx
+++ b/docs/pages/components/cldimage/basic-usage.mdx
@@ -30,6 +30,10 @@ The basic required props include `width`, `height`, `src`, and `alt`:
 />
 ```
 
+<Callout emoji={false}>
+  If using the Next.js 13 `app` directory, you must add the `use client;` directive at the top of your file.
+</Callout>
+
 The `src` property takes in a Cloudinary Public ID which includes the folder path along with the ID of the image itself.
 
 <Callout emoji={false}>

--- a/docs/pages/components/clduploadbutton/basic-usage.mdx
+++ b/docs/pages/components/clduploadbutton/basic-usage.mdx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { Callout } from 'nextra-theme-docs';
 
 import OgImage from '../../../components/OgImage';
 
@@ -26,6 +27,10 @@ At the core of it, CldUploadButton is a CldUploadWidget instance with a defined 
 ```jsx
 <CldUploadButton uploadPreset="next-cloudinary-unsigned" />
 ```
+
+<Callout emoji={false}>
+  If using the Next.js 13 `app` directory, you must add the `use client;` directive at the top of your file.
+</Callout>
 
 ## Learn More about CldUploadButton
 * [Configuration](/components/clduploadbutton/configuration)

--- a/docs/pages/components/clduploadbutton/configuration.mdx
+++ b/docs/pages/components/clduploadbutton/configuration.mdx
@@ -20,7 +20,8 @@ import OgImage from '../../../components/OgImage';
 | Prop Name          | Type               | Example                                |
 |--------------------|--------------------|----------------------------------------|
 | onClick            | function           | `function (event) { }`                 |
-| onUpload           | function           | `function (error, result, widget) { }` |
+| onError            | function           | `function (error, widget) { }`         |
+| onUpload           | function           | `function (result, widget) { }`        |
 | options            | object             | `{ encryption: {...} }`                |
 | signatureEndpoint  | string             | `"/api/sign-cloudinary-params.js"`     |
 | uploadPreset       | string             | `"my-upload-preset"`                   |

--- a/docs/pages/components/clduploadbutton/examples.mdx
+++ b/docs/pages/components/clduploadbutton/examples.mdx
@@ -22,7 +22,7 @@ import styles from '../../../styles/Docs.module.scss';
 
 # CldUploadButton Examples
 
-## Effects
+## Examples
 
 export const UnsignedUpload = () => {
   const [resource, setResource] = useState();
@@ -30,7 +30,7 @@ export const UnsignedUpload = () => {
     <>
       <CldUploadButton
         className={styles.button}
-        onUpload={(error, result, widget) => {
+        onUpload={(result, widget) => {
           setResource(result?.info);
           widget.close();
         }}
@@ -68,13 +68,9 @@ export const SignedUpload = () => {
 <ImageGrid>
   <li>
     <UnsignedUpload />
-
-    ### Unsigned
   </li>
   <li>
     <SignedUpload />
-
-    ### Signed
   </li>
 </ImageGrid>
 

--- a/docs/pages/components/clduploadbutton/examples.mdx
+++ b/docs/pages/components/clduploadbutton/examples.mdx
@@ -50,7 +50,7 @@ export const SignedUpload = () => {
     <>
       <CldUploadButton
         className={styles.button}
-        onUpload={(error, result, widget) => {
+        onUpload={(result, widget) => {
           setResource(result?.info);
           widget.close();
         }}

--- a/docs/pages/components/clduploadwidget/basic-usage.mdx
+++ b/docs/pages/components/clduploadwidget/basic-usage.mdx
@@ -56,6 +56,10 @@ Use the following to generate an unsigned upload widget:
 </CldUploadWidget>
 ```
 
+<Callout emoji={false}>
+  If using the Next.js 13 `app` directory, you must add the `use client;` directive at the top of your file.
+</Callout>
+
 ### Signed
 
 Signing upload requests requires passing in an endpoint to the component.
@@ -79,6 +83,10 @@ Use the following to generate an signed upload widget:
   }}
 </CldUploadWidget>
 ```
+
+<Callout emoji={false}>
+  If using the Next.js 13 `app` directory, you must add the `use client;` directive at the top of your file.
+</Callout>
 
 Here's an example of how you could process the signature in an API endpoint that signs a request:
 

--- a/docs/pages/components/clduploadwidget/configuration.mdx
+++ b/docs/pages/components/clduploadwidget/configuration.mdx
@@ -19,7 +19,8 @@ import OgImage from '../../../components/OgImage';
 
 | Prop Name          | Type               | Example                                |
 |--------------------|--------------------|----------------------------------------|
-| onUpload           | function           | `function (error, result, widget) { }` |
+| onError            | function           | `function (error, widget) { }`         |
+| onUpload           | function           | `function (result, widget) { }`        |
 | options            | object             | `{ encryption: {...} }`                |
 | signatureEndpoint  | string             | `"/api/sign-cloudinary-params.js"`     |
 | uploadPreset       | string             | `"my-upload-preset"`                   |

--- a/docs/pages/components/clduploadwidget/examples.mdx
+++ b/docs/pages/components/clduploadwidget/examples.mdx
@@ -70,7 +70,7 @@ export const SignedUpload = () => {
       <CldUploadWidget
         signatureEndpoint="/api/sign-cloudinary-params"
         uploadPreset="next-cloudinary-signed"
-        onUpload={(error, result, widget) => {
+        onUpload={(result, widget) => {
           setResource(result?.info);
           widget.close();
         }}

--- a/docs/pages/components/clduploadwidget/examples.mdx
+++ b/docs/pages/components/clduploadwidget/examples.mdx
@@ -29,7 +29,7 @@ export const MyDynamicButton = () => {
 
 # CldUploadWidget Examples
 
-## Effects
+## Examples
 
 export const UnsignedUpload = () => {
   const [resource, setResource] = useState();

--- a/docs/pages/components/clduploadwidget/examples.mdx
+++ b/docs/pages/components/clduploadwidget/examples.mdx
@@ -37,7 +37,7 @@ export const UnsignedUpload = () => {
     <>
       <CldUploadWidget
         uploadPreset="next-cloudinary-unsigned"
-        onUpload={(error, result, widget) => {
+        onUpload={(result, widget) => {
           setResource(result?.info);
           widget.close();
         }}

--- a/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
+++ b/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
@@ -9,6 +9,7 @@ export interface CldUploadButtonProps extends Omit<CldUploadWidgetProps, 'childr
 const CldUploadButton = ({
   children,
   onClick,
+  onError,
   onUpload,
   options,
   signatureEndpoint,
@@ -18,6 +19,7 @@ const CldUploadButton = ({
   return (
     <>
       <CldUploadWidget
+        onError={onError}
         onUpload={onUpload}
         options={options}
         signatureEndpoint={signatureEndpoint}

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Script from 'next/script';
 
 import { triggerOnIdle } from '../../lib/util';
@@ -18,6 +18,7 @@ export interface CldUploadWidgetPropsChildren {
 
 export interface CldUploadWidgetProps {
   children?: ({ cloudinary, widget, open }: CldUploadWidgetPropsChildren) => JSX.Element;
+  onError?: Function;
   onUpload?: Function;
   options?: CldUploadWidgetPropsOptions;
   signatureEndpoint?: URL | RequestInfo;
@@ -27,11 +28,31 @@ export interface CldUploadWidgetProps {
 const CldUploadWidget = ({
   children,
   onUpload,
+  onError,
   options,
   signatureEndpoint,
   uploadPreset,
 }: CldUploadWidgetProps) => {
+  const cloudinary: any = useRef();
+  const widget: any = useRef();
+
   const signed = !!signatureEndpoint;
+
+  const [error, setError] = useState(undefined);
+  const [results, setResults] = useState(undefined);
+
+  useEffect(() => {
+    if ( error && typeof onError === 'function' ) {
+      onError(error, widget.current);
+    }
+  }, [error]);
+
+  useEffect(() => {
+    if ( results && typeof onUpload === 'function' ) {
+      onUpload(results, widget.current);
+    }
+  }, [results]);
+
 
   /**
    * handleOnLoad
@@ -39,16 +60,16 @@ const CldUploadWidget = ({
    */
 
   function handleOnLoad() {
-    if ( !cloudinary ) {
-      cloudinary = (window as any).cloudinary;
+    if ( !cloudinary.current ) {
+      cloudinary.current = (window as any).cloudinary;
     }
 
     // To help improve load time of the widget on first instance, use requestIdleCallback
     // to trigger widget creation. Optional.
 
     triggerOnIdle(() => {
-      if ( !widget ) {
-        widget = createWidget();
+      if ( !widget.current ) {
+        widget.current = createWidget();
       }
     });
   }
@@ -102,22 +123,20 @@ const CldUploadWidget = ({
       }
     }
 
-    interface CreateUploadWidgetCallbackResult {
-      event: string;
-    }
+    return cloudinary.current?.createUploadWidget(uploadOptions, (uploadError: any, uploadResult: any) => {
+      // The callback is a bit more chatty than failed or success so
+      // only trigger when one of those are the case. You can additionally
+      // create a separate handler such as onEvent and trigger it on
+      // ever occurrence
 
-    return cloudinary?.createUploadWidget(
-      uploadOptions,
-      function (error: any, result: CreateUploadWidgetCallbackResult) {
-        // The callback is a bit more chatty than failed or success so
-        // only trigger when one of those are the case. You can additionally
-        // create a separate handler such as onEvent and trigger it on
-        // ever occurrence
-        if ((error || result.event === "success") && typeof onUpload === 'function') {
-          onUpload(error, result, widget);
-        }
+      if ( typeof uploadError !== 'undefined' ) {
+        setError(uploadError);
       }
-    );
+
+      if ( uploadResult?.event === 'success' ) {
+        setResults(uploadResult);
+      }
+    });
   }
 
   /**
@@ -126,17 +145,17 @@ const CldUploadWidget = ({
    */
 
   function open() {
-    if (!widget) {
-      widget = createWidget();
+    if (!widget.current) {
+      widget.current = createWidget();
     }
-    widget && widget.open();
+    widget.current && widget.current.open();
   }
 
   return (
-    <>
+    <React.Fragment key={Date.now()}>
       {typeof children === 'function' && children({
-        cloudinary,
-        widget,
+        cloudinary: cloudinary.current,
+        widget: widget.current,
         open,
       })}
       <Script
@@ -145,7 +164,7 @@ const CldUploadWidget = ({
         onLoad={handleOnLoad}
         onError={(e) => console.error(`Failed to load Cloudinary: ${e.message}`)}
       />
-    </>
+    </React.Fragment>
   );
 };
 

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -152,7 +152,7 @@ const CldUploadWidget = ({
   }
 
   return (
-    <React.Fragment key={Date.now()}>
+    <>
       {typeof children === 'function' && children({
         cloudinary: cloudinary.current,
         widget: widget.current,
@@ -164,7 +164,7 @@ const CldUploadWidget = ({
         onLoad={handleOnLoad}
         onError={(e) => console.error(`Failed to load Cloudinary: ${e.message}`)}
       />
-    </React.Fragment>
+    </>
   );
 };
 


### PR DESCRIPTION
# Description

The CldUploadWidget is facing an issue where the state setter isn't properly updating after route changes. I can't quite pin down the root problem, but my thinking is that due to the route changes, a reference is lost, and it's unable to work even though the callbacks seem to fire appropriately.

The solution proposed here is to take advantage of local state in the UploadWidget component to track the callback results and then bubble those up to the event handlers, including `onUpload` and newly added `onError`.

This is a breaking change, as `onUpload` will now remove the `error` argument as the first argument, given the `error` is tracked separately.

```
  <CldUploadWidget
        uploadPreset="next-cloudinary-unsigned"
        onUpload={(result, widget) => {
           // success
        }}
        onError={(result, widget) => {
           // error
        }}
      >
```

Questions:
* Would it make sense to store a single root state object with both the error and the result and triggering the handler logic based off of any changes to that? 
* Are there any negative consequences for tracking state this way? Only issue I can think of to start is user will need to add `use client` as it's now using client code

## Issue Ticket Number

Fixes #128 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
