### PR TITLE
Fixes Raw Transformations Conflicting with Resizing

### DIFF
--- a/docs/pages/components/cldimage/examples.mdx
+++ b/docs/pages/components/cldimage/examples.mdx
@@ -769,10 +769,7 @@ import ImageGrid from '../../../components/ImageGrid';
       width="960"
       height="600"
       src={`${process.env.IMAGES_DIRECTORY}/turtle`}
-      rawTransformations={[
-        'e_blur:2000',
-        'e_tint:100:0000FF:0p:FF1493:100p'
-      ]}
+      rawTransformations={['c_crop,h_359,w_517,x_1200,y_100/c_scale,h_359,w_517/f_auto,q_auto']}
       sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
     />
@@ -781,8 +778,8 @@ import ImageGrid from '../../../components/ImageGrid';
 
     ```jsx
     rawTransformations={[
-      'e_blur:2000',
-      'e_tint:100:0000FF:0p:FF1493:100p'
+      // Example from Cloudinary Media Editor widget
+      'c_crop,h_359,w_517,x_1483,y_0/c_scale,h_359,w_517/f_auto,q_auto'
     ]}
     ```
   </li>

--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -14,7 +14,7 @@
     "test:app": "NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=\"test\" yarn build && cd tests/nextjs-app && yarn build"
   },
   "dependencies": {
-    "@cloudinary-util/url-loader": "^2.0.0",
+    "@cloudinary-util/url-loader": "^3.0.0",
     "@cloudinary-util/util": "^2.0.0",
     "@cloudinary/url-gen": "^1.8.6"
   },

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -193,6 +193,30 @@ describe('Cloudinary Loader', () => {
       const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
       expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
+
+    it('should add any resizing after raw transformations', async () => {
+
+      const imageProps = {
+        height: '600',
+        sizes: '100vw',
+        src: 'images/turtle',
+        width: '960',
+      }
+
+      const loaderOptions = {
+        quality: 75,
+        src: 'images/turtle',
+        width: 960,
+      }
+
+      const cldOptions = {
+        rawTransformations: ['c_crop,h_359,w_517,x_1483,y_0/c_scale,h_359,w_517/f_auto,q_auto']
+      };
+
+      const result = cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig });
+
+      expect(result).toContain(`image/upload/${cldOptions.rawTransformations.join('/')}/c_limit,w_${imageProps.width}/f_auto/q_auto/v1/${imageProps.src}`)
+    });
   })
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudinary-util/url-loader@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@cloudinary-util/url-loader/-/url-loader-2.0.0.tgz#4d2921c08d86c775f40dd4d0d69f98771ae9a786"
-  integrity sha512-yDFwNM6c6puIsXwhhwfFcOqIf1v6ML+vVFTAqczpW9qSWGE73s/z2aJJdGLYJvFbpL8VlFmpf3WL3xGYRArt6A==
+"@cloudinary-util/url-loader@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@cloudinary-util/url-loader/-/url-loader-3.0.0.tgz#ba7b3538c60a6718dd3e2d49a9ec3bb33f27c494"
+  integrity sha512-WIpVpt7eSHU3zZux4PSOb7qY1vCF9/0BNFP0qKlQsD/71r7hrzZZx2cHNNk8VSdYY7iNtXgsFmn3LXYaNdkC4Q==
   dependencies:
     "@cloudinary-util/util" "2.0.0"
     "@cloudinary/url-gen" "^1.8.7"


### PR DESCRIPTION
# Description

This upgrades the URL loader to fix an issue with raw transformations conflicting with resizing.

The primary use case is that transformations performed outside of CldImage may be or likely will be working off of the original image's dimensions. Applying these after the resizing in CldImage will conflict.

For instance, if you have a 6000px wide image and apply a position of 5000px, if the image is first resized to 1000px, that 5000px coordinate wont exist, resulting in an error.

This is a breaking change as it moves the position of raw transformations to before the base width resizing

## Issue Ticket Number

Fixes #149 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
