### PR TITLE
CldOgImage Types Missing Definitions

### DIFF
--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -1,29 +1,26 @@
 import React from 'react';
 import Head from 'next/head';
 import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
+import type { ImageOptions } from '@cloudinary-util/url-loader';
 
 import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../../constants/analytics';
+import { CldImageProps } from '../CldImage/CldImage';
 
 const IMAGE_WIDTH = 2400;
 const IMAGE_HEIGHT = 1200;
 
 const TWITTER_CARD = 'summary_large_image';
 
-export interface CldOgImageProps {
-  alt: string;
-  crop?: string;
+export type CldOgImageProps = Omit<CldImageProps, 'width, height' > & {
   excludeTags?: Array<string>;
-  gravity?: string;
-  height: string | number;
-  src: string;
   twitterTitle?: string;
-  width: string | number;
 }
 
 const CldOgImage = ({ excludeTags = [], twitterTitle, ...props }: CldOgImageProps) => {
-  const options = {
+  const { alt } = props;
+
+  const options: ImageOptions = {
     ...props,
-    alt: props.alt,
     crop: props.crop || 'fill',
     gravity: props.gravity || 'center',
     height: props.height || IMAGE_HEIGHT,
@@ -56,8 +53,8 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, ...props }: CldOgImageProp
       <meta property="og:image:width" content={`${options.width}`} />
       <meta property="og:image:height" content={`${options.height}`} />
 
-      {options.alt && (
-        <meta property="og:image:alt" content={options.alt} />
+      {alt && (
+        <meta property="og:image:alt" content={alt} />
       )}
 
       {/* Required for summary_large_image, exclude vai excludeTags */}

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -11,7 +11,7 @@ const IMAGE_HEIGHT = 1200;
 
 const TWITTER_CARD = 'summary_large_image';
 
-export type CldOgImageProps = Omit<CldImageProps, 'width, height' > & {
+export type CldOgImageProps = CldImageProps & {
   excludeTags?: Array<string>;
   twitterTitle?: string;
 }


### PR DESCRIPTION
# Description

Currently some options are missing on CldOgImage Types including `overlays` which cause an error if attempted to be used in TypeScript.

This borrows the CldImage props, as it's basically the same, and uses ImageOptions from the URL construction to ensure everything checks out and is available.

## Issue Ticket Number

Fixes #166 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
