### PR TITLE
Add keys to CldOgImage to prevent excessive meta tag rendering

### DIFF
--- a/docs/pages/components/cldogimage/configuration.mdx
+++ b/docs/pages/components/cldogimage/configuration.mdx
@@ -26,6 +26,7 @@ See [CldImage](/components/cldimage/configuration) for all image transformations
 |--------------------|--------|------------------------------|
 | alt                | string | `"Next Cloudinary"`          |
 | excludeTags        | array  | `['twitter:title']`          |
+| keys               | object | `{'og:image': 'my-og-image'}`|
 | twitterTitle       | string | `"Next Cloudinary"`          |
 
 ## Excluding Tags
@@ -38,6 +39,30 @@ The `summary_large_image` Twitter card type requires the inclusion of a `twitter
 
 To exclude this tag to manage it on your own, use the `excludeTags` prop:
 
-```
+```jsx
 excludeTags={['twitter:title']}
+```
+
+## Keys
+
+By default, CldOgImage includes static keys on each meta tag rendered to help avoid duplication in the DOM.
+
+To allow customization and control in the event you want to minimize duplication with existing meta tags, you can specify custom keys for each tag.
+
+For instance, by default `og:image` tag will effectively render with:
+
+```jsx
+<meta key="og-image" property="og:image" content="..." />
+```
+
+Where if you pass in the `keys` prop with the following:
+
+```jsx
+keys={{'og:image': 'my-og-image'}}
+```
+
+The tag will render with:
+
+```jsx
+<meta key="og-image" property="my-og-image" content="..." />
 ```

--- a/docs/pages/components/cldogimage/configuration.mdx
+++ b/docs/pages/components/cldogimage/configuration.mdx
@@ -64,5 +64,5 @@ keys={{'og:image': 'my-og-image'}}
 The tag will render with:
 
 ```jsx
-<meta key="og-image" property="my-og-image" content="..." />
+<meta key="my-og-image" property="og:image" content="..." />
 ```

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -15,12 +15,13 @@ export interface CldOgImageProps {
   excludeTags?: Array<string>;
   gravity?: string;
   height: string | number;
+  keys: object;
   src: string;
   twitterTitle?: string;
   width: string | number;
 }
 
-const CldOgImage = ({ excludeTags = [], twitterTitle, ...props }: CldOgImageProps) => {
+const CldOgImage = ({ excludeTags = [], twitterTitle, keys, ...props }: CldOgImageProps) => {
   const options = {
     ...props,
     alt: props.alt,
@@ -29,6 +30,18 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, ...props }: CldOgImageProp
     height: props.height || IMAGE_HEIGHT,
     src: props.src,
     width: props.width || IMAGE_WIDTH,
+  }
+
+  const metaKeys = {
+    'og:image': 'og-image',
+    'og:image:secure_url': 'og-image-secureurl',
+    'og:image:width': 'og-image-width',
+    'og:image:height': 'og-image-height',
+    'og:image:alt': 'og-image-alt',
+    'twitter:title': 'twitter-title',
+    'twitter:card': 'twitter-card',
+    'twitter:image': 'twitter-image',
+    ...keys
   }
 
   const ogImageUrl = constructCloudinaryUrl({
@@ -51,24 +64,24 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, ...props }: CldOgImageProp
 
     return (
     <Head>
-      <meta property="og:image" content={ogImageUrl} />
-      <meta property="og:image:secure_url" content={ogImageUrl} />
-      <meta property="og:image:width" content={`${options.width}`} />
-      <meta property="og:image:height" content={`${options.height}`} />
+      <meta key={metaKeys['og:image']} property="og:image" content={ogImageUrl} />
+      <meta key={metaKeys['og:image:secure_url']} property="og:image:secure_url" content={ogImageUrl} />
+      <meta key={metaKeys['og:image:width']} property="og:image:width" content={`${options.width}`} />
+      <meta key={metaKeys['og:image:height']} property="og:image:height" content={`${options.height}`} />
 
       {options.alt && (
-        <meta property="og:image:alt" content={options.alt} />
+        <meta key={metaKeys['og:image:alt']} property="og:image:alt" content={options.alt} />
       )}
 
       {/* Required for summary_large_image, exclude vai excludeTags */}
       {/* https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image */}
 
       {!excludeTags.includes('twitter:title') && (
-        <meta property="twitter:title" content={twitterTitle || ' '} />
+        <meta key={metaKeys['twitter:title']} property="twitter:title" content={twitterTitle || ' '} />
       )}
 
-      <meta property="twitter:card" content={TWITTER_CARD} />
-      <meta property="twitter:image" content={ogImageUrl} />
+      <meta key={metaKeys['twitter:card']} property="twitter:card" content={TWITTER_CARD} />
+      <meta key={metaKeys['twitter:image']} property="twitter:image" content={ogImageUrl} />
     </Head>
   );
 }


### PR DESCRIPTION
# Description

When using CldOgImage in different locations, multiple sets of tags may be rendered.

By using Keys, we can avoid rendering duplication of meta tags.

This provides the ability to pass in custom keys as overrides

## Issue Ticket Number

Fixes #167 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
