### PR TITLE
Create and export getCldImageUrl

### DIFF
--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -14,7 +14,7 @@
     "test:app": "NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=\"test\" yarn build && cd tests/nextjs-app && yarn build"
   },
   "dependencies": {
-    "@cloudinary-util/url-loader": "^3.0.1",
+    "@cloudinary-util/url-loader": "^3.1.1",
     "@cloudinary-util/util": "^2.0.1",
     "@cloudinary/url-gen": "^1.8.6"
   },

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import Head from 'next/head';
-import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
 import type { ImageOptions } from '@cloudinary-util/url-loader';
 
-import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../../constants/analytics';
 import { CldImageProps } from '../CldImage/CldImage';
+import { getCldImageUrl } from '../../lib/cloudinary';
 
 const IMAGE_WIDTH = 2400;
 const IMAGE_HEIGHT = 1200;
@@ -41,20 +40,7 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
     ...keys
   }
 
-  const ogImageUrl = constructCloudinaryUrl({
-    options,
-    config: {
-      cloud: {
-        cloudName: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
-      }
-    },
-    analytics: {
-      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
-      sdkSemver: NEXT_CLOUDINARY_VERSION,
-      techVersion: NEXT_VERSION,
-      feature: ''
-    }
-  });
+  const ogImageUrl = getCldImageUrl(options);
 
   // We need to include the tags within the Next.js Head component rather than
   // direcly adding them inside of the Head otherwise we get unexpected results

--- a/next-cloudinary/src/index.ts
+++ b/next-cloudinary/src/index.ts
@@ -16,4 +16,7 @@ export type { CldVideoPlayerProps, CldVideoPlayerPropsColors, CldVideoPlayerProp
 export { cloudinaryLoader } from './loaders/cloudinary-loader';
 export type { CloudinaryLoader, CloudinaryLoaderLoaderOptions, CloudinaryLoaderCldOptions } from './loaders/cloudinary-loader';
 
+export { getCldImageUrl } from './lib/cloudinary';
+export type { GetCldImageUrl, GetCldImageUrlOptions, GetCldImageUrlConfig, GetCldImageUrlAnalytics } from './lib/cloudinary';
+
 export type { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsColors, CloudinaryVideoPlayerOptionsLogo } from './types/player';

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -7,6 +7,16 @@ import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } f
  * getCldImage
  */
 
+export interface GetCldImageUrlOptions extends ImageOptions {};
+export interface GetCldImageUrlConfig extends ConfigOptions {};
+export interface GetCldImageUrlAnalytics extends AnalyticsOptions {};
+
+export interface GetCldImageUrl {
+  options: GetCldImageUrlOptions;
+  config?: GetCldImageUrlConfig;
+  analytics?: GetCldImageUrlAnalytics;
+}
+
 export function getCldImageUrl(options: ImageOptions, config?: ConfigOptions, analytics?: AnalyticsOptions) {
   return constructCloudinaryUrl({
     options,
@@ -28,7 +38,7 @@ export function getCldImageUrl(options: ImageOptions, config?: ConfigOptions, an
  * pollForProcessingImage
  */
 
-interface PollForProcessingImageOptions {
+export interface PollForProcessingImageOptions {
   src: string;
 }
 

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -1,8 +1,38 @@
+import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
+import type { ImageOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
+
+import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
+
+/**
+ * getCldImage
+ */
+
+export function getCldImageUrl(options: ImageOptions, config?: ConfigOptions, analytics?: AnalyticsOptions) {
+  return constructCloudinaryUrl({
+    options,
+    config: Object.assign({
+      cloud: {
+        cloudName: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
+      },
+    }, config),
+    analytics: Object.assign({
+      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
+      sdkSemver: NEXT_CLOUDINARY_VERSION,
+      techVersion: NEXT_VERSION,
+      feature: ''
+    }, analytics)
+  });
+}
+
 /**
  * pollForProcessingImage
  */
 
-export async function pollForProcessingImage(options): Promise<boolean> {
+interface PollForProcessingImageOptions {
+  src: string;
+}
+
+export async function pollForProcessingImage(options: PollForProcessingImageOptions): Promise<boolean> {
   const { src } = options;
   try {
     await new Promise((resolve, reject) => {

--- a/next-cloudinary/src/loaders/cloudinary-loader.ts
+++ b/next-cloudinary/src/loaders/cloudinary-loader.ts
@@ -1,7 +1,6 @@
 import { ImageProps } from 'next/image';
-import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
 
-import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
+import { getCldImageUrl } from '../lib/cloudinary';
 
 export interface CloudinaryLoaderCldOptions {
   heightResize?: string | number;
@@ -22,7 +21,9 @@ export interface CloudinaryLoader {
 
 export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig = {} }: CloudinaryLoader) {
   const options = {
-    ...imageProps,
+    height: imageProps.height,
+    width: imageProps.width,
+    src: imageProps.src as string,
     ...cldOptions
   }
 
@@ -44,20 +45,5 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
     }
   }
 
-  return constructCloudinaryUrl({
-    // @ts-expect-error
-    options,
-    config: {
-      cloud: {
-        cloudName: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
-      },
-      ...cldConfig
-    },
-    analytics: {
-      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
-      sdkSemver: NEXT_CLOUDINARY_VERSION,
-      techVersion: NEXT_VERSION,
-      feature: ''
-    }
-  });
+  return getCldImageUrl(options, cldConfig);
 }

--- a/next-cloudinary/src/loaders/cloudinary-loader.ts
+++ b/next-cloudinary/src/loaders/cloudinary-loader.ts
@@ -21,9 +21,7 @@ export interface CloudinaryLoader {
 
 export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldConfig = {} }: CloudinaryLoader) {
   const options = {
-    height: imageProps.height,
-    width: imageProps.width,
-    src: imageProps.src as string,
+    ...imageProps,
     ...cldOptions
   }
 
@@ -45,5 +43,6 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
     }
   }
 
+  // @ts-ignore
   return getCldImageUrl(options, cldConfig);
 }

--- a/next-cloudinary/tests/lib/cloudinary.spec.js
+++ b/next-cloudinary/tests/lib/cloudinary.spec.js
@@ -1,8 +1,30 @@
+import { getCldImageUrl } from '../../src/lib/cloudinary';
+
 describe('Cloudinary', () => {
-  describe('pollForProcessingImage', () => {
-    // TODO: write tests for pollForProcessingImage
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  describe('getCldImage', () => {
     it('should pass', () => {
-      expect(true).toEqual(true);
+      const cloudName = 'customtestcloud';
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+
+      const url = getCldImageUrl({
+        src: 'turtle',
+        width: 100,
+        height: 100
+      });
+
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
     });
   });
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudinary-util/url-loader@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@cloudinary-util/url-loader/-/url-loader-3.0.1.tgz#a05889b628813e11b4ae527b304c1758db9e63f6"
-  integrity sha512-lJ3e+J3hrI8Q24Thg1Gdj+538YxZMP9cUs5AzUvIjGDrBObrRCovJ2xFi5AVGZXLcVY6nSXi+iCbtd8bCg8FZA==
+"@cloudinary-util/url-loader@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@cloudinary-util/url-loader/-/url-loader-3.1.1.tgz#f572fbb7f3e1acf2fcd8f6ea53777b5c4c19b59b"
+  integrity sha512-jR81afElp8GZJQrMHR9jW7ondDPKEsVD8LTSmFDTRZhMoPuRdljQNup8Tz4qOog7OxM+JS0+Gkn3j/fSmgEB8Q==
   dependencies:
     "@cloudinary-util/util" "2.0.1"
     "@cloudinary/url-gen" "^1.8.7"


### PR DESCRIPTION
# Description

Creates `getCldImageUrl` which is a wrapper around `constructCloudinaryUrl` which adds the default config and analytics options, allowing the first parameter to just be the options

This allows for URL construction using the same CldImage props

## Issue Ticket Number

Fixes #170 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
