### PR TITLE
Add isLoading to CldUploadWidget and CldUploadButton

### DIFF
--- a/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
+++ b/next-cloudinary/src/components/CldUploadButton/CldUploadButton.tsx
@@ -16,6 +16,7 @@ const CldUploadButton = ({
   uploadPreset,
   ...props
 }: CldUploadButtonProps) => {
+
   return (
     <>
       <CldUploadWidget
@@ -25,7 +26,7 @@ const CldUploadButton = ({
         signatureEndpoint={signatureEndpoint}
         uploadPreset={uploadPreset}
       >
-        {({ open }) => {
+        {({ open, isLoading }) => {
           function handleOnClick(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
             e.preventDefault();
 
@@ -36,7 +37,7 @@ const CldUploadButton = ({
             }
           }
           return (
-            <button {...props} onClick={handleOnClick} >
+            <button {...props} onClick={handleOnClick} disabled={isLoading} >
               {children || 'Upload'}
             </button>
           );

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -27,6 +27,7 @@ const CldUploadWidget = ({
 
   const [error, setError] = useState(undefined);
   const [results, setResults] = useState<CldUploadWidgetResults | undefined>(undefined);
+  const [isScriptLoading, setIsScriptLoading] = useState(true);
 
   // When creating a signed upload, you need to provide both your Cloudinary API Key
   // as well as a signature generator function that will sign any paramters
@@ -77,6 +78,7 @@ const CldUploadWidget = ({
    */
 
   function handleOnLoad() {
+    setIsScriptLoading(false);
     if ( !cloudinary.current ) {
       cloudinary.current = (window as any).cloudinary;
     }
@@ -158,8 +160,9 @@ const CldUploadWidget = ({
         widget: widget.current,
         open,
         results,
-        error
-      })}
+        error,
+        isLoading: isScriptLoading,
+        })}
       <Script
         id={`cloudinary-uploadwidget-${Math.floor(Math.random() * 100)}`}
         src="https://widget.cloudinary.com/v2.0/global/all.js"

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -15,6 +15,7 @@ export interface CldUploadWidgetPropsChildren {
   open: Function;
   results?: object;
   error?: any;
+  isLoading?: boolean;
 }
 
 // Parameters sourced from:


### PR DESCRIPTION
# Description

Add isLoading state for Cloudinary script to CldUploadWidget and use in CldUploadButton.

Since this changes the argument object that the CldUploadWidget provides, I assume we would also want to amend the documentation for CldUploadWidget to suit. Do you have any specifics you'd like to cover for this in the docs?

## Issue Ticket Number

Fixes #176 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [x] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
