### PR TITLE
getCldOgImageUrl & Docs with Next.js 13 App Usage

### DIFF
--- a/docs/pages/guides/nextjs-13.mdx
+++ b/docs/pages/guides/nextjs-13.mdx
@@ -25,10 +25,30 @@ By default, Next Cloudinary has full support when using the included components 
 
 # App Directory (Experimental)
 
+### General
+
 Using Next Cloudinary in the `app` directory currently requires marking the parent page or component as a Client Component.
 
 At the top of the file, add:
 
 ```
 use client;
+```
+
+### OG Images
+
+The Head component is not supported in the Next.js App directory, meaning, the [CldOgImage](/components/cldogimage/basic-usage) component will not function.
+
+Instead, you can easily generate OG image URLs using [getCldOgImageUrl](/helpers/getcldogimageurl/basic-usage) in your metadata configuration:
+
+
+```
+export const metadata = {
+  openGraph: {
+    ...
+    images: getCldOgImageUrl({
+      src: '<Public ID>'
+    })
+  },
+};
 ```

--- a/docs/pages/helpers/_meta.json
+++ b/docs/pages/helpers/_meta.json
@@ -1,3 +1,4 @@
 {
-  "getcldimageurl": "getCldImageUrl"
+  "getcldimageurl": "getCldImageUrl",
+  "getcldogimageurl": "getCldOgImageUrl"
 }

--- a/docs/pages/helpers/getcldimageurl/examples.mdx
+++ b/docs/pages/helpers/getcldimageurl/examples.mdx
@@ -35,6 +35,7 @@ import ImageGrid from '../../../components/ImageGrid';
       height="600"
       sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
+      preserveTransformations
     />
 
     ### Basic
@@ -59,6 +60,7 @@ import ImageGrid from '../../../components/ImageGrid';
       height="600"
       sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
+      preserveTransformations
     />
 
     ### Background Removal

--- a/docs/pages/helpers/getcldogimageurl/_meta.json
+++ b/docs/pages/helpers/getcldogimageurl/_meta.json
@@ -1,0 +1,5 @@
+{
+  "basic-usage": "Basic Usage",
+  "configuration": "Configuration",
+  "examples": "Examples"
+}

--- a/docs/pages/helpers/getcldogimageurl/basic-usage.mdx
+++ b/docs/pages/helpers/getcldogimageurl/basic-usage.mdx
@@ -1,0 +1,38 @@
+import Head from 'next/head';
+import { Callout } from 'nextra-theme-docs';
+
+import OgImage from '../../../components/OgImage';
+import Video from '../../../components/Video';
+
+<Head>
+  <title>getCldOgImageUrl - Next Cloudinary</title>
+  <meta name="og:title" content="Getting Started with getCldOgImageUrl - Next Cloudinary" />
+  <meta name="og:url" content={`https://next-cloudinary.spacejelly.dev/helpers/getcldogimageurl/basic-usage`} />
+</Head>
+
+<OgImage
+  title="getCldOgImageUrl"
+  twitterTitle="Getting Started with getCldOgImageUrl"
+/>
+
+# Getting Started with getCldOgImageUrl
+
+## Basic Usage
+
+getCldOgImage is intended to be a helper that extends [getCldImageUrl](/helpers/getcldimageurl/configuration) with basic defaults for social media usage.
+
+The only required prop is `src`:
+
+```js
+const url = getCldOgImageUrl({
+  src: '<Public ID>'
+});
+```
+
+Which would simply return the URL for the image public ID provided.
+
+Find out how else you can customize your Cloudinary image over on [getCldImageUrl configuration](/helpers/getcldimageurl/configuration).
+
+## Learn More about getCldOgImageUrl
+* [Configuration](/helpers/getcldogimageurl/configuration)
+* [Examples](/helpers/getcldogimageurl/examples)

--- a/docs/pages/helpers/getcldogimageurl/configuration.mdx
+++ b/docs/pages/helpers/getcldogimageurl/configuration.mdx
@@ -1,0 +1,31 @@
+import Head from 'next/head';
+
+import OgImage from '../../../components/OgImage';
+
+<Head>
+  <title>getCldOgImageUrl Configuration - Next Cloudinary</title>
+  <meta name="og:title" content="getCldOgImageUrl Configuration - Next Cloudinary" />
+  <meta name="og:url" content={`https://next-cloudinary.spacejelly.dev/helpers/getcldogimageurl/configuration`} />
+</Head>
+
+<OgImage
+  title="getCldOgImageUrl Configuration"
+  twitterTitle="getCldOgImageUrl Configuration"
+/>
+
+# getCldOgImageUrl Configuration
+
+Configuration for getCldOgImageUrl is the same as [getCldImageUrl](/helpers/getcldimageurl/configuration).
+
+The only difference is getCldOgImageUrl provides the following default settings to make generating an OG image URL simpler:
+
+## General Options
+
+| Option Name        | Type               | Default    | Example                      |
+|--------------------|--------------------|------------|------------------------------|
+| crop               | string             | `"fill"`   | `"scale"`                    |
+| gravity            | string             | `"center"` | `"auto"`                     |
+| height             | number             | `1200`     | `1200`                       |
+| width              | number             | `2400`     | `2400`                       |
+
+Find more configuration settings over at [getCldImageUrl configuration](/helpers/getcldimageurl/configuration).

--- a/docs/pages/helpers/getcldogimageurl/examples.mdx
+++ b/docs/pages/helpers/getcldogimageurl/examples.mdx
@@ -69,7 +69,7 @@ import ImageGrid from '../../../components/ImageGrid';
     ```
   </li>
   <li>
-    <img
+    <CldImage
       src={getCldOgImageUrl({
         src: `${process.env.IMAGES_DIRECTORY}/white`,
         text: 'Next Cloudinary'
@@ -78,6 +78,7 @@ import ImageGrid from '../../../components/ImageGrid';
       height="1200"
       sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
+      preserveTransformations
     />
 
     ### Basic Text

--- a/docs/pages/helpers/getcldogimageurl/examples.mdx
+++ b/docs/pages/helpers/getcldogimageurl/examples.mdx
@@ -1,0 +1,92 @@
+import Head from 'next/head';
+import { Callout } from 'nextra-theme-docs';
+
+import { CldImage, getCldOgImageUrl } from '../../../../next-cloudinary';
+
+import OgImage from '../../../components/OgImage';
+import ImageGrid from '../../../components/ImageGrid';
+
+<Head>
+  <title>getCldOgImageUrl Examples - Next Cloudinary</title>
+  <meta name="og:title" content="getCldOgImageUrl Examples - Next Cloudinary" />
+  <meta name="og:url" content={`https://next-cloudinary.spacejelly.dev/helpers/getcldogimageurl/examples`} />
+</Head>
+
+<OgImage
+  title="getCldOgImageUrl Examples"
+  twitterTitle="getCldOgImageUrl Examples"
+/>
+
+# getCldOgImageUrl Examples
+
+<Callout emoji={false}>
+  The below examples use the CldImage component to render the images. This is not required, you can use the URL returned by getCldOgImageUrl in any way you like.
+</Callout>
+
+<ImageGrid>
+  <li>
+    <CldImage
+      src={getCldOgImageUrl({
+        src: `${process.env.IMAGES_DIRECTORY}/galaxy`,
+      })}
+      width="2400"
+      height="1200"
+      sizes="(max-width: 480px) 100vw, 50vw"
+      alt=""
+      preserveTransformations
+    />
+
+    ### Basic
+
+    ```js
+    getCldOgImageUrl({
+      src: 'images/galaxy',
+    })
+    ```
+  </li>
+  <li>
+    <CldImage
+      src={getCldOgImageUrl({
+        src: `${process.env.IMAGES_DIRECTORY}/turtle`,
+        removeBackground: true,
+        underlay: `${process.env.IMAGES_DIRECTORY}/galaxy`,
+      })}
+      width="2400"
+      height="1200"
+      sizes="(max-width: 480px) 100vw, 50vw"
+      alt=""
+      preserveTransformations
+    />
+
+    ### Background Removal & Underlay
+
+    ```js
+    getCldOgImageUrl({
+      src: 'images/turtle',
+      removeBackground: true,
+      underlay: 'images/galaxy'
+    })
+    ```
+  </li>
+  <li>
+    <img
+      src={getCldOgImageUrl({
+        src: `${process.env.IMAGES_DIRECTORY}/white`,
+        text: 'Next Cloudinary'
+      })}
+      width="2400"
+      height="1200"
+      sizes="(max-width: 480px) 100vw, 50vw"
+      alt=""
+    />
+
+    ### Basic Text
+
+    ```js
+    getCldOgImageUrl({
+      src: 'images/white',
+      text: 'Next Cloudinary'
+    })
+    ```
+  </li>
+</ImageGrid>

--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -62,7 +62,7 @@ const CldImage = (props: CldImageProps) => {
 
   if (props.preserveTransformations) {
     try {
-      const transformations = getTransformations(props.src);
+      const transformations = getTransformations(props.src).map(t => t.join(','));
       // @ts-expect-error
       cldOptions.rawTransformations = [...transformations.flat(), ...(props.rawTransformations || [])];
     } catch(e) {

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -3,10 +3,8 @@ import Head from 'next/head';
 import type { ImageOptions } from '@cloudinary-util/url-loader';
 
 import { CldImageProps } from '../CldImage/CldImage';
-import { getCldImageUrl } from '../../lib/cloudinary';
-
-const IMAGE_WIDTH = 2400;
-const IMAGE_HEIGHT = 1200;
+import { getCldImageUrl } from '../../helpers/getCldImageUrl';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../constants/sizes';
 
 const TWITTER_CARD = 'summary_large_image';
 
@@ -23,9 +21,9 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
     ...props,
     crop: props.crop || 'fill',
     gravity: props.gravity || 'center',
-    height: props.height || IMAGE_HEIGHT,
+    height: props.height || OG_IMAGE_HEIGHT,
     src: props.src,
-    width: props.width || IMAGE_WIDTH,
+    width: props.width || OG_IMAGE_WIDTH,
   }
 
   const metaKeys = {

--- a/next-cloudinary/src/constants/sizes.ts
+++ b/next-cloudinary/src/constants/sizes.ts
@@ -1,0 +1,2 @@
+export const OG_IMAGE_WIDTH = 2400;
+export const OG_IMAGE_HEIGHT = 1200;

--- a/next-cloudinary/src/helpers/getCldImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldImageUrl.ts
@@ -1,0 +1,35 @@
+import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
+import type { ImageOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
+
+import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
+
+/**
+ * getCldImage
+ */
+
+export interface GetCldImageUrlOptions extends ImageOptions {};
+export interface GetCldImageUrlConfig extends ConfigOptions {};
+export interface GetCldImageUrlAnalytics extends AnalyticsOptions {};
+
+export interface GetCldImageUrl {
+  options: GetCldImageUrlOptions;
+  config?: GetCldImageUrlConfig;
+  analytics?: GetCldImageUrlAnalytics;
+}
+
+export function getCldImageUrl(options: ImageOptions, config?: ConfigOptions, analytics?: AnalyticsOptions) {
+  return constructCloudinaryUrl({
+    options,
+    config: Object.assign({
+      cloud: {
+        cloudName: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
+      },
+    }, config),
+    analytics: Object.assign({
+      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
+      sdkSemver: NEXT_CLOUDINARY_VERSION,
+      techVersion: NEXT_VERSION,
+      feature: ''
+    }, analytics)
+  });
+}

--- a/next-cloudinary/src/helpers/getCldOgImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldOgImageUrl.ts
@@ -1,0 +1,20 @@
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../constants/sizes';
+
+import { getCldImageUrl } from './getCldImageUrl';
+import type { GetCldImageUrl, GetCldImageUrlOptions } from './getCldImageUrl';
+
+/**
+ * getCldImageUrl
+ */
+
+export interface GetCldOgImageUrl extends GetCldImageUrl {}
+
+export function getCldOgImageUrl(options: GetCldImageUrlOptions) {
+  return getCldImageUrl({
+    ...options,
+    crop: options.crop || 'fill',
+    gravity: options.gravity || 'center',
+    height: options.height || OG_IMAGE_HEIGHT,
+    width: options.width || OG_IMAGE_WIDTH,
+  });
+}

--- a/next-cloudinary/src/index.ts
+++ b/next-cloudinary/src/index.ts
@@ -16,7 +16,10 @@ export type { CldVideoPlayerProps, CldVideoPlayerPropsColors, CldVideoPlayerProp
 export { cloudinaryLoader } from './loaders/cloudinary-loader';
 export type { CloudinaryLoader, CloudinaryLoaderLoaderOptions, CloudinaryLoaderCldOptions } from './loaders/cloudinary-loader';
 
-export { getCldImageUrl } from './lib/cloudinary';
-export type { GetCldImageUrl, GetCldImageUrlOptions, GetCldImageUrlConfig, GetCldImageUrlAnalytics } from './lib/cloudinary';
+export { getCldImageUrl } from './helpers/getCldImageUrl';
+export type { GetCldImageUrl, GetCldImageUrlOptions, GetCldImageUrlConfig, GetCldImageUrlAnalytics } from './helpers/getCldImageUrl';
+
+export { getCldOgImageUrl } from './helpers/getCldOgImageUrl';
+export type { GetCldOgImageUrl } from './helpers/getCldOgImageUrl';
 
 export type { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsColors, CloudinaryVideoPlayerOptionsLogo } from './types/player';

--- a/next-cloudinary/src/lib/cloudinary.ts
+++ b/next-cloudinary/src/lib/cloudinary.ts
@@ -1,39 +1,3 @@
-import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
-import type { ImageOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
-
-import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
-
-/**
- * getCldImage
- */
-
-export interface GetCldImageUrlOptions extends ImageOptions {};
-export interface GetCldImageUrlConfig extends ConfigOptions {};
-export interface GetCldImageUrlAnalytics extends AnalyticsOptions {};
-
-export interface GetCldImageUrl {
-  options: GetCldImageUrlOptions;
-  config?: GetCldImageUrlConfig;
-  analytics?: GetCldImageUrlAnalytics;
-}
-
-export function getCldImageUrl(options: ImageOptions, config?: ConfigOptions, analytics?: AnalyticsOptions) {
-  return constructCloudinaryUrl({
-    options,
-    config: Object.assign({
-      cloud: {
-        cloudName: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
-      },
-    }, config),
-    analytics: Object.assign({
-      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
-      sdkSemver: NEXT_CLOUDINARY_VERSION,
-      techVersion: NEXT_VERSION,
-      feature: ''
-    }, analytics)
-  });
-}
-
 /**
  * pollForProcessingImage
  */

--- a/next-cloudinary/src/loaders/cloudinary-loader.ts
+++ b/next-cloudinary/src/loaders/cloudinary-loader.ts
@@ -1,6 +1,6 @@
 import { ImageProps } from 'next/image';
 
-import { getCldImageUrl } from '../lib/cloudinary';
+import { getCldImageUrl } from '../helpers/getCldImageUrl';
 
 export interface CloudinaryLoaderCldOptions {
   heightResize?: string | number;

--- a/next-cloudinary/tests/lib/cloudinary.spec.js
+++ b/next-cloudinary/tests/lib/cloudinary.spec.js
@@ -1,4 +1,4 @@
-import { getCldImageUrl } from '../../src/lib/cloudinary';
+import { getCldImageUrl } from '../../src/helpers/getCldImageUrl';
 
 describe('Cloudinary', () => {
   const OLD_ENV = process.env;


### PR DESCRIPTION
# Description

* Adds the getCldOgImageUrl helper to assist in generating a social image to use in Next.js metadata
* Adds docs for component
* Adds Next.js 13 App dir documentation
* Fixes preserveTransformations to re-apply transformations as they were pulled from original URL

## Issue Ticket Number

Fixes #169 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
