### PR TITLE
Social Image Format & Size

### DIFF
--- a/docs/pages/components/cldogimage/basic-usage.mdx
+++ b/docs/pages/components/cldogimage/basic-usage.mdx
@@ -27,7 +27,7 @@ The basic required prop is `src`:
 />
 ```
 
-Place this anywhere outside of the Head component.
+Place the CldOgImage component anywhere outside of the Head component.
 
 <Callout emoji={false}>
   The CldOgImage component must be placed outside of the Next.js Head component as the Head component does not accept React components as children.
@@ -39,8 +39,8 @@ The resulting HTML will be applied to the Head of the document:
 ```html
 <meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/f_auto/q_auto/v1/images/galaxy" />
 <meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/f_auto/q_auto/v1/images/galaxy" />
-<meta property="og:image:width" content="2400" />
-<meta property="og:image:height" content="1200" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="600" />
 <meta property="twitter:title" content=" " />
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/f_auto/q_auto/v1/images/galaxy" />

--- a/docs/pages/components/cldogimage/basic-usage.mdx
+++ b/docs/pages/components/cldogimage/basic-usage.mdx
@@ -37,13 +37,13 @@ Place the CldOgImage component anywhere outside of the Head component.
 The resulting HTML will be applied to the Head of the document:
 
 ```html
-<meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/f_auto/q_auto/v1/images/galaxy" />
-<meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/f_auto/q_auto/v1/images/galaxy" />
+<meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/c_scale,w_1200/f_jpg/q_auto/v1/images/galaxy" />
+<meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/c_scale,w_1200/f_jpg/q_auto/v1/images/galaxy" />
 <meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="600" />
+<meta property="og:image:height" content="627" />
 <meta property="twitter:title" content=" " />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/f_auto/q_auto/v1/images/galaxy" />
+<meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/c_scale,w_1200/f_webp/q_auto/v1/images/galaxy" />
 ```
 
 But you can use any of the available features from [CldImage](/components/cldimage/configuration) to build your CldOgImage.

--- a/docs/pages/components/cldogimage/configuration.mdx
+++ b/docs/pages/components/cldogimage/configuration.mdx
@@ -45,9 +45,11 @@ The height is ultimately calculated using the `width` value and the `widthResize
 
 While Cloudinary's `f_auto` parameter (format of auto) is great for websites and mobile apps, having more control over the format helps to reduce initial encoding time, which is more critical for a social network to recognize the image and load it on first share.
 
-The default format then is jpg, as webp does not have broad support (likely nor does AVIF).
+The default format for most use cases is then jpg, as webp does not have broad support (likely nor does AVIF).
 
 Read more about webp support: https://www.ctrl.blog/entry/webp-ogp.html
+
+However, Twitter does support webp, so we're able to customize the format using the Twitter specific tag, and generally a separate webp version for that platform to optimize where we can.
 
 ## Excluding Tags
 

--- a/docs/pages/components/cldogimage/configuration.mdx
+++ b/docs/pages/components/cldogimage/configuration.mdx
@@ -45,7 +45,7 @@ While Cloudinary's `f_auto` parameter (format of auto) is great for websites and
 
 The default format then is jpg, as webp does not have broad support (likely nor does AVIF).
 
-Read more about webp support: <https://www.ctrl.blog/entry/webp-ogp.html>
+Read more about webp support: https://www.ctrl.blog/entry/webp-ogp.html
 
 ## Excluding Tags
 

--- a/docs/pages/components/cldogimage/configuration.mdx
+++ b/docs/pages/components/cldogimage/configuration.mdx
@@ -29,6 +29,24 @@ See [CldImage](/components/cldimage/configuration) for all image transformations
 | keys               | object | `{'og:image': 'my-og-image'}`|
 | twitterTitle       | string | `"Next Cloudinary"`          |
 
+## Image Size
+
+By default, the image canvas is based upon 2400x1200, but resized down to 1200x600, meaning, you can design the image as if it were a 2400x1200 image, but the ersulting image will be sized down to 1200x600 to avoid an overly large image.
+
+This provides backwards compatibility for existing usage as well as a way to maintain a consistent "canvas" size when designing a social image card.
+
+You can use the `width` and the `height` to control the canvas and `widthResize` to change the final size the image is scaled to.
+
+The height is ultimately calculated using the `width` value and the `widthResize` values to maintain the correct ratio.
+
+## Image Format
+
+While Cloudinary's `f_auto` parameter (format of auto) is great for websites and mobile apps, having more control over the format helps to reduce initial encoding time, which is more critical for a social network to recognize the image and load it on first share.
+
+The default 
+
+https://www.ctrl.blog/entry/webp-ogp.html
+
 ## Excluding Tags
 
 The `summary_large_image` Twitter card type requires the inclusion of a `twitter:title` card. Because of this, the component includes it by default for simplified use along with a prop to change the value.

--- a/docs/pages/components/cldogimage/configuration.mdx
+++ b/docs/pages/components/cldogimage/configuration.mdx
@@ -43,9 +43,9 @@ The height is ultimately calculated using the `width` value and the `widthResize
 
 While Cloudinary's `f_auto` parameter (format of auto) is great for websites and mobile apps, having more control over the format helps to reduce initial encoding time, which is more critical for a social network to recognize the image and load it on first share.
 
-The default 
+The default format then is jpg, as webp does not have broad support (likely nor does AVIF).
 
-https://www.ctrl.blog/entry/webp-ogp.html
+Read more about webp support: <https://www.ctrl.blog/entry/webp-ogp.html>
 
 ## Excluding Tags
 

--- a/docs/pages/components/cldogimage/configuration.mdx
+++ b/docs/pages/components/cldogimage/configuration.mdx
@@ -31,9 +31,11 @@ See [CldImage](/components/cldimage/configuration) for all image transformations
 
 ## Image Size
 
-By default, the image canvas is based upon 2400x1200, but resized down to 1200x600, meaning, you can design the image as if it were a 2400x1200 image, but the ersulting image will be sized down to 1200x600 to avoid an overly large image.
+By default, the image canvas is based upon 2400x1254, but resized down to 1200x627, meaning, you can design the image as if it were a 2400x1254 image, but the resulting image will be sized down to 1200x627 to avoid an overly large image.
 
-This provides backwards compatibility for existing usage as well as a way to maintain a consistent "canvas" size when designing a social image card.
+627 (with a canvas of 1254) is used to satisfy the 1.91:1 ratio requirement and minimum size [requirement from linkedin](https://www.linkedin.com/help/linkedin/answer/a521928/make-your-website-shareable-on-linkedin).
+
+The resizing mechanism provides backwards compatibility for existing usage as well as a way to maintain a consistent "canvas" size when designing a social image card.
 
 You can use the `width` and the `height` to control the canvas and `widthResize` to change the final size the image is scaled to.
 

--- a/docs/pages/components/cldogimage/examples.mdx
+++ b/docs/pages/components/cldogimage/examples.mdx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import { Callout } from 'nextra-theme-docs';
 
 import { CldImage } from '../../../../next-cloudinary';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../../../next-cloudinary/src/constants/sizes';
 
 import OgImage from '../../../components/OgImage';
 import ImageGrid from '../../../components/ImageGrid';
@@ -28,8 +29,8 @@ import ImageGrid from '../../../components/ImageGrid';
 <ImageGrid columns={1}>
   <li>
     <CldImage
-      width="2400"
-      height="1200"
+      width={OG_IMAGE_WIDTH}
+      height={OG_IMAGE_HEIGHT}
       crop="fill"
       gravity="auto"
       src={`${process.env.IMAGES_DIRECTORY}/white`}
@@ -46,8 +47,8 @@ import ImageGrid from '../../../components/ImageGrid';
   </li>
   <li>
     <CldImage
-      width="2400"
-      height="1200"
+      width={OG_IMAGE_WIDTH}
+      height={OG_IMAGE_HEIGHT}
       crop="fill"
       gravity="auto"
       src={`${process.env.IMAGES_DIRECTORY}/turtle`}

--- a/docs/pages/helpers/getcldogimageurl/basic-usage.mdx
+++ b/docs/pages/helpers/getcldogimageurl/basic-usage.mdx
@@ -31,6 +31,40 @@ const url = getCldOgImageUrl({
 
 Which would simply return the URL for the image public ID provided.
 
+## Image Size
+
+By default, the image canvas is based upon 2400x1254, but resized down to 1200x627, meaning, you can design the image as if it were a 2400x1254 image, but the resulting image will be sized down to 1200x627 to avoid an overly large image.
+
+627 (with a canvas of 1254) is used to satisfy the 1.91:1 ratio requirement and minimum size [requirement from linkedin](https://www.linkedin.com/help/linkedin/answer/a521928/make-your-website-shareable-on-linkedin).
+
+The resizing mechanism provides backwards compatibility for existing usage as well as a way to maintain a consistent "canvas" size when designing a social image card.
+
+You can use the `width` and the `height` to control the canvas and `widthResize` to change the final size the image is scaled to.
+
+The height is ultimately calculated using the `width` value and the `widthResize` values to maintain the correct ratio.
+
+## Image Format
+
+While Cloudinary's `f_auto` parameter (format of auto) is great for websites and mobile apps, having more control over the format helps to reduce initial encoding time, which is more critical for a social network to recognize the image and load it on first share.
+
+The safe default format for most use cases is then jpg, as webp does not have broad support (likely nor does AVIF).
+
+Read more about webp support: https://www.ctrl.blog/entry/webp-ogp.html
+
+If you have the control in your application to produce multiple image sources, such has having a separate `og:image` and `twitter:image`, you can generate two (or more) URLs to produce as optimized a format as you can for the platform:
+
+```
+const ogImageUrl = getCldImageUrl({
+  ...options,
+  format: 'jpg',
+});
+
+const twitterImageUrl = getCldImageUrl({
+  ...options,
+  format: 'webp',
+});
+```
+
 Find out how else you can customize your Cloudinary image over on [getCldImageUrl configuration](/helpers/getcldimageurl/configuration).
 
 ## Learn More about getCldOgImageUrl

--- a/docs/pages/helpers/getcldogimageurl/configuration.mdx
+++ b/docs/pages/helpers/getcldogimageurl/configuration.mdx
@@ -25,7 +25,7 @@ The only difference is getCldOgImageUrl provides the following default settings 
 |--------------------|--------------------|------------|------------------------------|
 | crop               | string             | `"fill"`   | `"scale"`                    |
 | gravity            | string             | `"center"` | `"auto"`                     |
-| height             | number             | `1200`     | `1200`                       |
+| height             | number             | `1254`     | `1254`                       |
 | width              | number             | `2400`     | `2400`                       |
 
 Find more configuration settings over at [getCldImageUrl configuration](/helpers/getcldimageurl/configuration).

--- a/docs/pages/helpers/getcldogimageurl/examples.mdx
+++ b/docs/pages/helpers/getcldogimageurl/examples.mdx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import { Callout } from 'nextra-theme-docs';
 
 import { CldImage, getCldOgImageUrl } from '../../../../next-cloudinary';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../../../next-cloudinary/src/constants/sizes';
 
 import OgImage from '../../../components/OgImage';
 import ImageGrid from '../../../components/ImageGrid';
@@ -29,8 +30,8 @@ import ImageGrid from '../../../components/ImageGrid';
       src={getCldOgImageUrl({
         src: `${process.env.IMAGES_DIRECTORY}/galaxy`,
       })}
-      width="2400"
-      height="1200"
+      width={OG_IMAGE_WIDTH}
+      height={OG_IMAGE_HEIGHT}
       sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
       preserveTransformations
@@ -51,8 +52,8 @@ import ImageGrid from '../../../components/ImageGrid';
         removeBackground: true,
         underlay: `${process.env.IMAGES_DIRECTORY}/galaxy`,
       })}
-      width="2400"
-      height="1200"
+      width={OG_IMAGE_WIDTH}
+      height={OG_IMAGE_HEIGHT}
       sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
       preserveTransformations
@@ -74,8 +75,8 @@ import ImageGrid from '../../../components/ImageGrid';
         src: `${process.env.IMAGES_DIRECTORY}/white`,
         text: 'Next Cloudinary'
       })}
-      width="2400"
-      height="1200"
+      width={OG_IMAGE_WIDTH}
+      height={OG_IMAGE_HEIGHT}
       sizes="(max-width: 480px) 100vw, 50vw"
       alt=""
       preserveTransformations

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -110,8 +110,8 @@ import { CldOgImage } from 'next-cloudinary';
 ```html
 <meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />
 <meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />
-<meta property="og:image:width" content="2400" />
-<meta property="og:image:height" content="1200" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="600" />
 <meta property="twitter:title" content=" " />
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -109,13 +109,13 @@ import { CldOgImage } from 'next-cloudinary';
 />
 
 ```html
-<meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />
-<meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />
+<meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/c_scale,w_1200/f_jpg/q_auto/v1/images/galaxy" />
+<meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/c_scale,w_1200/f_jpg/q_auto/v1/images/galaxy" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="627" />
 <meta property="twitter:title" content=" " />
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />
+<meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1254,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/c_scale,w_1200/f_webp/q_auto/v1/images/galaxy" />
 ```
 
 ### More Resources

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -4,6 +4,7 @@ import { Callout } from 'nextra-theme-docs';
 import OgImage from '../components/OgImage';
 
 import { CldImage } from '../../next-cloudinary';
+import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../next-cloudinary/src/constants/sizes';
 
 <Head>
   <title>Installation - Next Cloudinary</title>
@@ -94,8 +95,8 @@ import { CldOgImage } from 'next-cloudinary';
 </Callout>
 
 <CldImage
-  width="2400"
-  height="1200"
+  width={OG_IMAGE_WIDTH}
+  height={OG_IMAGE_HEIGHT}
   crop="fill"
   gravity="auto"
   src={`${process.env.IMAGES_DIRECTORY}/galaxy`}
@@ -111,7 +112,7 @@ import { CldOgImage } from 'next-cloudinary';
 <meta property="og:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />
 <meta property="og:image:secure_url" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />
 <meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="600" />
+<meta property="og:image:height" content="627" />
 <meta property="twitter:title" content=" " />
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:image" content="https://res.cloudinary.com/colbycloud-next-cloudinary/image/upload/c_fill,w_2400,h_1200,g_center/l_text:Arial_200_bold:Installation,co_white/fl_layer_apply,fl_no_overflow/f_auto/q_auto/v1/images/galaxy" />

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -20,7 +20,6 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
   const options: ImageOptions = {
     ...props,
     crop: props.crop || 'fill',
-    format: props.format || 'jpg',
     gravity: props.gravity || 'center',
     height: props.height || OG_IMAGE_HEIGHT,
     src: props.src,
@@ -37,6 +36,20 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
     height = ( options.width / OG_IMAGE_WIDTH_RESIZE ) * height;
   }
 
+  // Render the final URLs. We use two different format versions to deliver
+  // webp for Twitter as it supports it (and we can control with tags) where
+  // other platforms may not support webp, so we deliver jpg
+
+  const ogImageUrl = getCldImageUrl({
+    ...options,
+    format: props.format || 'jpg',
+  });
+
+  const twitterImageUrl = getCldImageUrl({
+    ...options,
+    format: props.format || 'webp',
+  });
+
   const metaKeys = {
     'og:image': 'og-image',
     'og:image:secure_url': 'og-image-secureurl',
@@ -48,8 +61,6 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
     'twitter:image': 'twitter-image',
     ...keys
   }
-
-  const ogImageUrl = getCldImageUrl(options);
 
   // We need to include the tags within the Next.js Head component rather than
   // direcly adding them inside of the Head otherwise we get unexpected results
@@ -73,7 +84,7 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
       )}
 
       <meta key={metaKeys['twitter:card']} property="twitter:card" content={TWITTER_CARD} />
-      <meta key={metaKeys['twitter:image']} property="twitter:image" content={ogImageUrl} />
+      <meta key={metaKeys['twitter:image']} property="twitter:image" content={twitterImageUrl} />
     </Head>
   );
 }

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -27,14 +27,16 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
     widthResize: props.width || OG_IMAGE_WIDTH_RESIZE
   }
 
-  const width = typeof options.width === 'string' ? parseInt(options.width) : options.width;
+  let width = typeof options.width === 'string' ? parseInt(options.width) : options.width;
   let height = typeof options.height === 'string' ? parseInt(options.height) : options.height;
 
   // Resize the height based on the widthResize property
 
-  if ( typeof height === 'number' && typeof options.width === 'number' ) {
-    height = ( OG_IMAGE_WIDTH_RESIZE / options.width ) * height;
+  if ( typeof height === 'number' && typeof width === 'number' ) {
+    height = ( OG_IMAGE_WIDTH_RESIZE / width ) * height;
   }
+
+  width = OG_IMAGE_WIDTH_RESIZE;
 
   // Render the final URLs. We use two different format versions to deliver
   // webp for Twitter as it supports it (and we can control with tags) where

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -33,7 +33,7 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
   // Resize the height based on the widthResize property
 
   if ( typeof height === 'number' && typeof options.width === 'number' ) {
-    height = ( options.width / OG_IMAGE_WIDTH_RESIZE ) * height;
+    height = ( OG_IMAGE_WIDTH_RESIZE / options.width ) * height;
   }
 
   // Render the final URLs. We use two different format versions to deliver

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -4,7 +4,7 @@ import type { ImageOptions } from '@cloudinary-util/url-loader';
 
 import { CldImageProps } from '../CldImage/CldImage';
 import { getCldImageUrl } from '../../helpers/getCldImageUrl';
-import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../../constants/sizes';
+import { OG_IMAGE_WIDTH, OG_IMAGE_WIDTH_RESIZE, OG_IMAGE_HEIGHT } from '../../constants/sizes';
 
 const TWITTER_CARD = 'summary_large_image';
 
@@ -20,10 +20,21 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
   const options: ImageOptions = {
     ...props,
     crop: props.crop || 'fill',
+    format: props.format || 'webp',
     gravity: props.gravity || 'center',
     height: props.height || OG_IMAGE_HEIGHT,
     src: props.src,
     width: props.width || OG_IMAGE_WIDTH,
+    widthResize: props.width || OG_IMAGE_WIDTH_RESIZE
+  }
+
+  const width = typeof options.width === 'string' ? parseInt(options.width) : options.width;
+  let height = typeof options.height === 'string' ? parseInt(options.height) : options.height;
+
+  // Resize the height based on the widthResize property
+
+  if ( typeof height === 'number' && typeof options.width === 'number' ) {
+    height = ( options.width / OG_IMAGE_WIDTH_RESIZE ) * height;
   }
 
   const metaKeys = {
@@ -47,8 +58,8 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
     <Head>
       <meta key={metaKeys['og:image']} property="og:image" content={ogImageUrl} />
       <meta key={metaKeys['og:image:secure_url']} property="og:image:secure_url" content={ogImageUrl} />
-      <meta key={metaKeys['og:image:width']} property="og:image:width" content={`${options.width}`} />
-      <meta key={metaKeys['og:image:height']} property="og:image:height" content={`${options.height}`} />
+      <meta key={metaKeys['og:image:width']} property="og:image:width" content={`${width}`} />
+      <meta key={metaKeys['og:image:height']} property="og:image:height" content={`${height}`} />
 
       {alt && (
         <meta key={metaKeys['og:image:alt']} property="og:image:alt" content={alt} />

--- a/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
+++ b/next-cloudinary/src/components/CldOgImage/CldOgImage.tsx
@@ -20,7 +20,7 @@ const CldOgImage = ({ excludeTags = [], twitterTitle, keys = {}, ...props }: Cld
   const options: ImageOptions = {
     ...props,
     crop: props.crop || 'fill',
-    format: props.format || 'webp',
+    format: props.format || 'jpg',
     gravity: props.gravity || 'center',
     height: props.height || OG_IMAGE_HEIGHT,
     src: props.src,

--- a/next-cloudinary/src/constants/sizes.ts
+++ b/next-cloudinary/src/constants/sizes.ts
@@ -1,3 +1,3 @@
 export const OG_IMAGE_WIDTH = 2400;
 export const OG_IMAGE_WIDTH_RESIZE = 1200;
-export const OG_IMAGE_HEIGHT = 1200;
+export const OG_IMAGE_HEIGHT = 1254;

--- a/next-cloudinary/src/constants/sizes.ts
+++ b/next-cloudinary/src/constants/sizes.ts
@@ -1,2 +1,3 @@
 export const OG_IMAGE_WIDTH = 2400;
+export const OG_IMAGE_WIDTH_RESIZE = 1200;
 export const OG_IMAGE_HEIGHT = 1200;

--- a/next-cloudinary/src/helpers/getCldOgImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldOgImageUrl.ts
@@ -1,4 +1,4 @@
-import { OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT } from '../constants/sizes';
+import { OG_IMAGE_WIDTH, OG_IMAGE_WIDTH_RESIZE, OG_IMAGE_HEIGHT } from '../constants/sizes';
 
 import { getCldImageUrl } from './getCldImageUrl';
 import type { GetCldImageUrl, GetCldImageUrlOptions } from './getCldImageUrl';
@@ -13,8 +13,10 @@ export function getCldOgImageUrl(options: GetCldImageUrlOptions) {
   return getCldImageUrl({
     ...options,
     crop: options.crop || 'fill',
+    format: options.format || 'jpg',
     gravity: options.gravity || 'center',
     height: options.height || OG_IMAGE_HEIGHT,
     width: options.width || OG_IMAGE_WIDTH,
+    widthResize: options.width || OG_IMAGE_WIDTH_RESIZE
   });
 }


### PR DESCRIPTION
# Description

* Reduces social image size by default to 1200x600 using widthResize to preserve backwards compat
* Forces format to avoid slower encoding times for quick requests on first share

## Issue Ticket Number

Fixes #189 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
