### PR TITLE
Fixes rerenders caused by parent renders

### DIFF
--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import Image, { ImageProps } from 'next/image';
 import { getTransformations } from '@cloudinary-util/util';
 import { transformationPlugins } from '@cloudinary-util/url-loader';
@@ -26,20 +26,19 @@ const CldImage = (props: CldImageProps) => {
       }
       CLD_OPTIONS.push(prop);
     });
-  })
+  });
 
   // Construct the base Image component props by filtering out Cloudinary-specific props
 
   const imageProps = {
     alt: props.alt,
-    src: props.src
+    src: props.src,
   };
 
   (Object.keys(props) as Array<keyof typeof props>)
     .filter(key => !CLD_OPTIONS.includes(key))
     // @ts-expect-error
     .forEach(key => imageProps[key] = props[key]);
-
 
   const defaultImgKey = (Object.keys(imageProps) as Array<keyof typeof imageProps>).map(key => `${key}:${imageProps[key]}`).join(';');
   const [imgKey, setImgKey] = useState(defaultImgKey);
@@ -78,12 +77,14 @@ const CldImage = (props: CldImageProps) => {
     target: any;
   }
 
-  async function handleOnError(options: HandleOnError) {
+  async function onError(options: HandleOnError) {
     const result = await pollForProcessingImage({ src: options.target.src })
     if ( result ) {
       setImgKey(`${defaultImgKey};${Date.now()}`);
     }
   }
+
+  const handleOnError = useCallback(onError, [pollForProcessingImage, defaultImgKey]);
 
   return (
     <Image


### PR DESCRIPTION
# Description

Any time the parent renders, CldImage force reloads.

This is due to creating a new function for every render for the onError prop to Image component

Fixes it by wrapping onError with a useCallback instance.

## Issue Ticket Number

Fixes #206 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
