### PR TITLE
onError Callback

### DIFF
--- a/docs/pages/components/cldimage/configuration.mdx
+++ b/docs/pages/components/cldimage/configuration.mdx
@@ -28,6 +28,7 @@ Configuration for CldImage is the same as [getCldImageUrl](/helpers/getcldimageu
 | format             | string             | `"auto"`   | `"webp"`                     |
 | gravity            | string             | `"auto"`   | `"faces"`                    |
 | height             | number/string      | -          | `600`                        |
+| onError            | function/bool      | -          | `(event) => {}`              |
 | overlays           | array              | -          | See Below                    |
 | preserveTransformations | string        | `false`    | `true`                       |
 | quality            | string             | `"auto"`   | `"90"`                       |

--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -74,12 +74,27 @@ const CldImage = (props: CldImageProps) => {
    * handleOnError
    */
 
-  interface HandleOnError {
-    target: any;
-  }
+  async function onError(options: React.SyntheticEvent<HTMLImageElement, Event>) {
+    let pollForImage = true;
 
-  async function onError(options: HandleOnError) {
-    const result = await pollForProcessingImage({ src: options.target.src })
+    if ( typeof props.onError === 'function' ) {
+      const onErrorResult = props.onError(options);
+
+      if ( typeof onErrorResult === 'boolean' && onErrorResult === false ) {
+        pollForImage = false;
+      }
+    } else if ( typeof props.onError === 'boolean' && props.onError === false ) {
+      pollForImage = false;
+    }
+
+    // Give an escape hatch in case the user wants to handle the error themselves
+    // or if they want to disable polling for the image
+
+    if ( pollForImage === false ) return;
+
+    const image = options.target as HTMLImageElement
+    const result = await pollForProcessingImage({ src: image.src })
+
     if ( result ) {
       setImgKey(`${defaultImgKey};${Date.now()}`);
     }


### PR DESCRIPTION
# Description

Allows for the caller to pass through `onError` to the Next.js Image component as expected.

This allows the caller to also return false from the `onError` callback to dynamically disable polling or simply pass `false` into the prop

## Issue Ticket Number

Fixes #216 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
