### PR TITLE
CldVideoPlayer URL src

### DIFF
--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, MutableRefObject } from 'react';
 import Script from 'next/script';
 import Head from 'next/head';
+import { parseUrl } from '@cloudinary-util/util';
 
 import { CldVideoPlayerProps } from './CldVideoPlayer.types';
 import { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsLogo } from '../../types/player';
@@ -37,6 +38,19 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
   } = props as CldVideoPlayerProps;
 
   const playerTransformations = Array.isArray(transformation) ? transformation : [transformation];
+  let publicId = src;
+
+  // If the publicId/src is a URL, attempt to parse it as a Cloudinary URL
+  // to get the public ID alone
+
+  if ( publicId.startsWith('http') ) {
+    try {
+      const parts = parseUrl(src);
+      if ( typeof parts?.publicId === 'string' ) {
+        publicId = parts?.publicId;
+      }
+    } catch(e) {}
+  }
 
   // Set default transformations for the player
 
@@ -53,7 +67,7 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
   const defaultPlayerRef = useRef()as MutableRefObject<CloudinaryVideoPlayer | null>;
   const playerRef = props.playerRef || defaultPlayerRef;
 
-  const playerId = id || `player-${src.replace('/', '-')}-${idRef.current}`;
+  const playerId = id || `player-${publicId.replace('/', '-')}-${idRef.current}`;
   let playerClassName = 'cld-video-player cld-fluid';
 
   if ( className ) {
@@ -111,7 +125,7 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
         fontFace: fontFace || '',
         loop,
         muted,
-        publicId: src,
+        publicId,
         secure: true,
         transformation: playerTransformations,
         ...logoOptions


### PR DESCRIPTION
# Description

Sets up the CldVideoPlayer to allow passing in a valid Cloudinary URL as a src

Example: 
```
src="https://res.cloudinary.com/next-cloudinary/video/upload/v1/videos/mountain-stars.webm"
```

Similar to CldImage, the URL must include a version number `/v1234/`

## Issue Ticket Number

Fixes #236 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
