### PR TITLE
Remove optimizations with unoptimized prop

### DIFF
--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -5,13 +5,15 @@ import { transformationPlugins } from '@cloudinary-util/url-loader';
 import type { ImageOptions, ConfigOptions } from '@cloudinary-util/url-loader';
 
 import { pollForProcessingImage } from '../../lib/cloudinary';
+import { getCldImageUrl } from '../../helpers/getCldImageUrl';
 
 import { cloudinaryLoader } from '../../loaders/cloudinary-loader';
 
 export type CldImageProps = Omit<ImageProps, 'src'> & ImageOptions & {
-  src: string;
-  preserveTransformations?: boolean;
   config?: ConfigOptions;
+  preserveTransformations?: boolean;
+  src: string;
+  unoptimized?: boolean;
 };
 
 const CldImage = (props: CldImageProps) => {
@@ -31,7 +33,7 @@ const CldImage = (props: CldImageProps) => {
 
   // Construct the base Image component props by filtering out Cloudinary-specific props
 
-  const imageProps = {
+  const imageProps: ImageProps = {
     alt: props.alt,
     src: props.src,
   };
@@ -46,7 +48,7 @@ const CldImage = (props: CldImageProps) => {
 
   // Construct Cloudinary-specific props by looking for values for any of the supported prop keys
 
-  const cldOptions = {};
+  const cldOptions: Omit<ImageOptions, 'src'> = {};
 
   CLD_OPTIONS.forEach(key => {
     // @ts-expect-error
@@ -63,11 +65,24 @@ const CldImage = (props: CldImageProps) => {
   if (props.preserveTransformations) {
     try {
       const transformations = getTransformations(props.src).map(t => t.join(','));
-      // @ts-expect-error
       cldOptions.rawTransformations = [...transformations.flat(), ...(props.rawTransformations || [])];
     } catch(e) {
       console.warn(`Failed to preserve transformations: ${(e as Error).message}`)
     }
+  }
+
+  // The unoptimized flag is intended to remove all optimizations including quality, format, and sizing
+  // via responsive sizing. When passing this in, it also prevents the `loader` from running, thus
+  // breaking this component. This rewrites the `src` to construct a fully formed Cloudinary URL
+  // that also disables format and quality transformations, to deliver it as unoptimized
+
+  if ( props.unoptimized === true ) {
+    imageProps.src = getCldImageUrl({
+      ...cldOptions,
+      format: 'default',
+      quality: 'default',
+      src: imageProps.src as string
+    }, props.config);
   }
 
   /**


### PR DESCRIPTION
# Description

When the `unoptimized` flag is passed in, this removes the f_auto/q_auto optimizations from the Cloudinary URL.

It will also construct a full Cloudinary URL as the src, otherwise the public ID is attempted to be used, which results in ab broken URL. This usually wouldn't be allowed but it seems the unoptimized flag bypasses the image allowed list.

This doesn't fix this issue occuring when the unoptimized flag is passed in globally inside next.config.js

## Issue Ticket Number

Fixes #245 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
