### PR TITLE
Fixes global unoptimized flag from breaking URLs

### DIFF
--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -77,12 +77,16 @@ const CldImage = (props: CldImageProps) => {
   // that also disables format and quality transformations, to deliver it as unoptimized
   // See about unoptimized not working with loader: https://github.com/vercel/next.js/issues/50764
 
-  if ( props.unoptimized === true ) {
+  const IMAGE_OPTIONS: { unoptimized?: boolean } = (process.env.__NEXT_IMAGE_OPTS || {}) as unknown as object;
+
+  if ( props.unoptimized === true || IMAGE_OPTIONS?.unoptimized === true ) {
     imageProps.src = getCldImageUrl({
       ...cldOptions,
+      width: imageProps.width,
+      height: imageProps.height,
+      src: imageProps.src as string,
       format: 'default',
       quality: 'default',
-      src: imageProps.src as string
     }, props.config);
   }
 


### PR DESCRIPTION
# Description

The next.config.js image options are available through `process.env.__NEXT_IMAGE_OPTS` giving the ability to inspect if the `unoptimized` flag is turned on.

If thats the case, we build the `src` prop manually outside of the loader logic to prevent broken image URLs.

## Issue Ticket Number

Fixes #252 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
