### PR TITLE
Fixes CldUploadWidget post message error

### DIFF
--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -153,7 +153,7 @@ const CldUploadWidget = ({
     }
 
     if ( typeof widget?.current[method] === 'function' ) {
-      widget.current[method](widget.current);
+      widget.current[method]();
     }
   }
 


### PR DESCRIPTION
# Description

Opening the upload widget triggers an error dealing with posting a message along with the open method.

The problem was I, for some reason, was passing in the widget instance as an argument to the instance methods themselves, which isn't valid.

By doing that, and the way that hte upload widget communicates, my understanding is it was trying to pass what should be serializable data through the [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) function that relates to the widget itself, where the instance method isn't serializable.

Simply removing the invalid argument fixes this issue.

## Issue Ticket Number

Fixes #259 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
