### PR TITLE
CldVideoPlayer bug fix forcing to be string

### DIFF
--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -38,7 +38,7 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
   } = props as CldVideoPlayerProps;
 
   const playerTransformations = Array.isArray(transformation) ? transformation : [transformation];
-  let publicId = src;
+  let publicId: string = src || "";
 
   if ( typeof props.version === 'string' ) {
     console.warn('The version prop will no longer be supported in future versions due to the unreliability of coordinating assets');


### PR DESCRIPTION
# Description
Setting the source variable to be always a string. So will avoid crashes with string method into a posible not string ( null, undefined, etx variables)
<img width="369" alt="Captura de pantalla 2023-10-01 a las 13 01 06" src="https://github.com/colbyfayock/next-cloudinary/assets/26023012/faa8b3ac-60c8-4a9d-8fb5-b5002e4e88dc">


<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Added String type to the soruce variable
Added a default value of an empty string if the value is a null/undefined.
BUG FIX : https://github.com/colbyfayock/next-cloudinary/issues/286

Fixes #286 
https://github.com/colbyfayock/next-cloudinary/issues/286
<!-- Specify above which issue this fixes by referencing the issue number (`#286`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x ] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
