### PR TITLE
Allow user to dynamically specify cloud name

### DIFF
--- a/next-cloudinary/src/helpers/getCldImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldImageUrl.ts
@@ -18,11 +18,12 @@ export interface GetCldImageUrl {
 }
 
 export function getCldImageUrl(options: ImageOptions, config?: ConfigOptions, analytics?: AnalyticsOptions) {
+  const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
   return constructCloudinaryUrl({
     options,
     config: Object.assign({
       cloud: {
-        cloudName: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
+        cloudName: cloudName
       },
     }, config),
     analytics: Object.assign({


### PR DESCRIPTION
# Description

Fix to stop overriding user's cloud name if they pass in one in the cloudinary config.

## Issue
[Issue](https://github.com/colbyfayock/next-cloudinary/issues/290)

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
