### PR TITLE
Stop generating CldVideoPlayer ID using Math.random.

### DIFF
--- a/docs/pages/cldvideoplayer/basic-usage.mdx
+++ b/docs/pages/cldvideoplayer/basic-usage.mdx
@@ -44,6 +44,7 @@ import 'next-cloudinary/dist/cld-video-player.css';
   width="1620"
   height="1080"
   src={`${process.env.VIDEOS_DIRECTORY}/mountain-stars`}
+  id={'one'}
 />
 
 ## Customization

--- a/docs/pages/cldvideoplayer/basic-usage.mdx
+++ b/docs/pages/cldvideoplayer/basic-usage.mdx
@@ -41,10 +41,10 @@ import 'next-cloudinary/dist/cld-video-player.css';
 ```
 
 <CldVideoPlayer
+  id="basic"
   width="1620"
   height="1080"
   src={`${process.env.VIDEOS_DIRECTORY}/mountain-stars`}
-  id={'one'}
 />
 
 ## Customization
@@ -66,6 +66,7 @@ You can further take advantage of features like customizing your player:
 ```
 
 <CldVideoPlayer
+  id="customization"
   width="1620"
   height="1080"
   src={`${process.env.VIDEOS_DIRECTORY}/mountain-stars`}

--- a/docs/pages/cldvideoplayer/examples.mdx
+++ b/docs/pages/cldvideoplayer/examples.mdx
@@ -40,6 +40,7 @@ export const VideoPlayerWithRef = (props) => {
 <ImageGrid columns={1}>
   <li>
     <CldVideoPlayer
+      id="default"
       width="1620"
       height="1080"
       src={`${process.env.VIDEOS_DIRECTORY}/mountain-stars`}
@@ -58,6 +59,7 @@ export const VideoPlayerWithRef = (props) => {
   <li>
     <div style={{ maxWidth: 500, margin: '0 auto' }}>
       <CldVideoPlayer
+        id="crop-resize"
         width="500"
         height="500"
         src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
@@ -82,6 +84,7 @@ export const VideoPlayerWithRef = (props) => {
   </li>
   <li>
     <CldVideoPlayer
+      id="transformation-overlay"
       width="1620"
       height="1080"
       src={`${process.env.VIDEOS_DIRECTORY}/mountain-stars`}
@@ -113,6 +116,7 @@ export const VideoPlayerWithRef = (props) => {
   </li>
   <li>
     <CldVideoPlayer
+      id="custom-colors-font"
       width="4096"
       height="2160"
       src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
@@ -139,6 +143,7 @@ export const VideoPlayerWithRef = (props) => {
   </li>
   <li>
     <CldVideoPlayer
+      id="custom-logo"
       width="4096"
       height="2160"
       src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
@@ -161,6 +166,7 @@ export const VideoPlayerWithRef = (props) => {
   </li>
   <li>
     <VideoPlayerWithRef
+      id="with-ref"
       width="4096"
       height="2160"
       src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -6,7 +6,7 @@ import { parseUrl } from '@cloudinary-util/util';
 import { CldVideoPlayerProps } from './CldVideoPlayer.types';
 import { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsLogo } from '../../types/player';
 
-let playerInstances: Record<string, string> = {};
+let playerInstances: string[] = [];
 
 const CldVideoPlayer = (props: CldVideoPlayerProps) => {
 
@@ -75,12 +75,14 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
     playerClassName = `${playerClassName} ${className}`;
   }
 
-  if (playerInstances[playerId]) {
+  // Check if the same id is being used for multiple video instances.
+  const checkForMultipleInstance = playerInstances.filter((id) => id === playerId).length > 1
+  if (checkForMultipleInstance) {
     console.warn(`Multiple instances of the same video detected on the
      page which may cause some features to not work. 
     Try adding a unique id to each player.`)
   } else {
-    playerInstances[playerId] = playerId
+    playerInstances.push(playerId)
   }
 
   const events: Record<string, Function|undefined> = {

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -181,7 +181,7 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
           height={height}
         />
         <Script
-          id={`cloudinary-videoplayer-${Math.floor(Math.random() * 100)}`}
+          id={`cloudinary-videoplayer-${playerId}`}
           src={`https://unpkg.com/cloudinary-video-player@${version}/dist/cld-video-player.min.js`}
           onLoad={handleOnLoad}
           onError={(e) => console.error(`Failed to load Cloudinary Video Player: ${e.message}`)}

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -6,12 +6,9 @@ import { parseUrl } from '@cloudinary-util/util';
 import { CldVideoPlayerProps } from './CldVideoPlayer.types';
 import { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsLogo } from '../../types/player';
 
+let playerInstances: Record<string, string> = {};
+
 const CldVideoPlayer = (props: CldVideoPlayerProps) => {
-  // If no ID is passed in - we want to be able to ensure that we are using
-  // unique IDs for each player. We can do this by generating a random number
-  // and using that as the ID. We use a ref here so that we can ensure that
-  // the ID is only generated once.
-  const idRef = useRef(Math.ceil(Math.random() * 100000));
 
   const {
     autoPlay = 'never',
@@ -71,11 +68,19 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
   const defaultPlayerRef = useRef()as MutableRefObject<CloudinaryVideoPlayer | null>;
   const playerRef = props.playerRef || defaultPlayerRef;
 
-  const playerId = id || `player-${publicId.replace('/', '-')}-${idRef.current}`;
+  const playerId = id || `player-${publicId.replace('/', '-')}`;
   let playerClassName = 'cld-video-player cld-fluid';
 
   if ( className ) {
     playerClassName = `${playerClassName} ${className}`;
+  }
+
+  if (playerInstances[playerId]) {
+    console.warn(`Multiple instances of the same video detected on the
+     page which may cause some features to not work. 
+    Try adding a unique id to each player.`)
+  } else {
+    playerInstances[playerId] = playerId
   }
 
   const events: Record<string, Function|undefined> = {

--- a/next-cloudinary/src/types/player.ts
+++ b/next-cloudinary/src/types/player.ts
@@ -13,6 +13,9 @@ export interface CloudinaryVideoPlayerOptions {
   publicId: string;
   secure?: boolean;
   transformation?: Array<object> | object;
+  showLogo?: boolean;
+  logoImageUrl?: string;
+  logoOnclickUrl?: string;
 }
 
 export interface CloudinaryVideoPlayerOptionsColors {


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->

- Removed the `idRef` generated with Math.random.
- Generate a Player ID using the public id or the `id` provided through the props. 
- Throw a console warning when two or more instances of the same video are identified stating to the user to provide a unique id for each video. 
- Add types of `showLogo`, `logoImageUrl`,  `logoOnclickUrl` for the logo object to the `CloudinaryVideoPlayerOptions` interface.  

## Issue Ticket Number
 #281

Fixes #<ISSUE_NUMBER>
Fixes #281

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change
<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
