### PR TITLE
Fixes no responsive sizing when using Fill

### DIFF
--- a/next-cloudinary/src/loaders/cloudinary-loader.ts
+++ b/next-cloudinary/src/loaders/cloudinary-loader.ts
@@ -41,6 +41,14 @@ export function cloudinaryLoader({ loaderOptions, imageProps, cldOptions, cldCon
     if ( typeof options.height === 'number' ) {
       options.heightResize = Math.round(options.height * multiplier);
     }
+  } else if ( typeof loaderOptions?.width === 'number' && typeof options?.width !== 'number' ) {
+    // If we don't have a width on the options object, this may mean that the component is using
+    // the fill option: https://nextjs.org/docs/pages/api-reference/components/image#fill
+    // The Fill option does not allow someone to pass in a width or a height
+    // If this is the case, we still need to define a width for sizing optimization but also
+    // for responsive sizing to take effect, so we can utilize the loader width for the base width
+    options.width = loaderOptions.width;
+    options.widthResize = loaderOptions.width;
   }
 
   // @ts-ignore

--- a/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
+++ b/next-cloudinary/tests/loaders/cloudinary-loader.spec.js
@@ -194,6 +194,30 @@ describe('Cloudinary Loader', () => {
       expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/fetch/c_fill,w_${imageProps.width},h_${imageProps.height},g_auto/l_fetch:${urlParam}/fl_layer_apply,fl_no_overflow/c_scale,w_${loaderOptions3.width}/f_auto/q_auto/https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg`)
     });
 
+    it('should add any resizing when fill is set to true without a width or height', async () => {
+      const imageProps = {
+        sizes: '100vw',
+        src: 'images/woman-headphones',
+        fill: true
+      }
+
+      const cldOptions = {};
+
+      // The resulting widths should only be resized from imageProps if the value is smaller, to avoid upscaling an image
+
+      const loaderOptions1 = { width: 2048 };
+      const result1 = cloudinaryLoader({ loaderOptions: loaderOptions1, imageProps, cldOptions, cldConfig });
+      expect(result1).toContain(`https://res.cloudinary.com/test-cloud/image/upload/c_limit,w_${loaderOptions1.width}/f_auto/q_auto/v1/${imageProps.src}`)
+
+      const loaderOptions2 = { width: 3840 };
+      const result2 = cloudinaryLoader({ loaderOptions: loaderOptions2, imageProps, cldOptions, cldConfig });
+      expect(result2).toContain(`https://res.cloudinary.com/test-cloud/image/upload/c_limit,w_${loaderOptions2.width}/f_auto/q_auto/v1/${imageProps.src}`)
+
+      const loaderOptions3 = { width: 640 };
+      const result3 = cloudinaryLoader({ loaderOptions: loaderOptions3, imageProps, cldOptions, cldConfig });
+      expect(result3).toContain(`https://res.cloudinary.com/test-cloud/image/upload/c_limit,w_${loaderOptions3.width}/f_auto/q_auto/v1/${imageProps.src}`)
+    });
+
     it('should add any resizing after raw transformations', async () => {
 
       const imageProps = {


### PR DESCRIPTION
# Description

When setting `fill` on `CldImage`, responsive sizing is lost.

This is because the loader previously expected a width to always be present in order to set the responsive sizing, in our case, using the `widthResize` property for the URL builder.

This uses the width passed through from the Next Image loader function that's used to generate the responsive sizing to build a URL that will scale down to that size.

## Issue Ticket Number

Fixes #295 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
