### PR TITLE
Video Poster

### DIFF
--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -33,6 +33,7 @@
   },
   "getcldimageurl": "getCldImageUrl",
   "getcldogimageurl": "getCldOgImageUrl",
+  "getcldvideourl": "getCldVideoUrl",
   "Resources": {
     "type": "separator",
     "title": "Resources"

--- a/docs/pages/cldvideoplayer/configuration.mdx
+++ b/docs/pages/cldvideoplayer/configuration.mdx
@@ -21,22 +21,22 @@ import OgImage from '../../components/OgImage';
 |--------------------|----------------|-----------------|------------------------------------------|------------------------------|
 | autoPlay           | string         | `"never"`       | When, if, should the video automatically play. See `autoplayMode` in [Video Player docs](https://cloudinary.com/documentation/video_player_api_reference#constructor_parameters) | `"on-scroll"`          |
 | className          | string         | -               | Additional class names added to the video container | `"my-video-player"`      |
-| colors             | object         | See below       | Player chrome colors                     | See Colors Below             |
+| colors             | object         | See below       | Player chrome colors                     | See Customizing the Player Theme Colors Below             |
 | controls           | boolean        | `true`          | Show player controls                     | `true`                       |
 | fontFace           | string         | -               | Player UI font. Uses Google Fonts.       | `"Source Serif Pro"`         |
 | height             | string/number  | -               | **Required**: Player height              | `1080`                       |
 | id                 | string         | -               | Video instance ID, defaults to src value | `"my-video"`                 |
-| logo               | boolean/object | See Below       | Logo to display in Player UI             | See Logo Below               |
+| logo               | boolean/object | See Below       | Logo to display in Player UI             | See Setting a Custom Logo Below |
 | loop               | boolean        | `false`         | Loop the video                           | `true`                       |
 | muted              | boolean        | `false`         | Load muted by default                    | `true`                       |
-| onDataLoad         | Function       | -               | Triggered when video metadata is loaded  | See Events Below             |
-| onError            | Function       | -               | Triggered on video error                 | See Events Below             |
-| onMetadataLoad     | Function       | -               | Triggered when video data is loaded      | See Events Below             |
-| onPause            | Function       | -               | Triggered on video pause                 | See Events Below             |
-| onPlay             | Function       | -               | Triggered on video play                  | See Events Below             |
-| onEnded            | Function       | -               | Triggered when video has ended play      | See Events Below             |
+| onDataLoad         | Function       | -               | Triggered when video metadata is loaded  | See Custom Event Handlers Below             |
+| onError            | Function       | -               | Triggered on video error                 | See Custom Event Handlers Below             |
+| onMetadataLoad     | Function       | -               | Triggered when video data is loaded      | See Custom Event Handlers Below             |
+| onPause            | Function       | -               | Triggered on video pause                 | See Custom Event Handlers Below             |
+| onPlay             | Function       | -               | Triggered on video play                  | See Custom Event Handlers Below             |
+| onEnded            | Function       | -               | Triggered when video has ended play      | See Custom Event Handlers Below             |
 | playerRef          | Ref            | -               | React ref to access Player instance      | See Refs Below               |
-| poster             | string/object  | -               | Customize the video's poster             | See Refs Below               |
+| poster             | string/object  | -               | Customize the video's poster             | See Customizing a Video's Poster Below            |
 | showLogo           | boolea         | `true`          | Show the Cloudinary logo on Player       | `false`                      |
 | src                | string         | -               | **Required**: Video public ID            | `"videos/my-video"`          |
 | sourceTypes        | array          | -               | Streaming format                         | `['hls']`                    |
@@ -46,7 +46,7 @@ import OgImage from '../../components/OgImage';
 
 Missing an option from the [Video Player docs](https://cloudinary.com/documentation/video_player_api_reference) you'd like to see? [Create an issue](https://github.com/colbyfayock/next-cloudinary/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=%5BFeature%5D+)!
 
-## Colors Prop
+## Customizing the Player Theme Colors
 
 The `colors` prop takes an object that can control what colors are used in the player:
 
@@ -58,7 +58,7 @@ The `colors` prop takes an object that can control what colors are used in the p
 
 Learn more about the color scheme options and how they're used [on the Cloudinary docs](https://cloudinary.com/documentation/video_player_customization#color_scheme).
 
-## Event Props
+## Custom Event Handlers
 
 The event props allow you to pass in a function that is called whenever the associated event occurs.
 
@@ -70,7 +70,7 @@ For instance, in order to trigger an event whenever a video is paused:
 }} ... />
 ```
 
-## Logo Prop
+## Setting a Custom Logo
 
 The `logo` prop gives the option to customize the player's logo.
 
@@ -97,7 +97,7 @@ ID to render an automatically generated preview image.
 
 [View examples](/cldvideoplayer/examples#poster).
 
-## Ref Props
+## Refs
 
 The `playerRef` and `videoRef` props give you the ability to pass in your own ref to gain access to both the Player instance as well as the HTML video element on which the player is mounted.
 

--- a/docs/pages/cldvideoplayer/configuration.mdx
+++ b/docs/pages/cldvideoplayer/configuration.mdx
@@ -36,6 +36,7 @@ import OgImage from '../../components/OgImage';
 | onPlay             | Function       | -               | Triggered on video play                  | See Events Below             |
 | onEnded            | Function       | -               | Triggered when video has ended play      | See Events Below             |
 | playerRef          | Ref            | -               | React ref to access Player instance      | See Refs Below               |
+| poster             | string/object  | -               | Customize the video's poster             | See Refs Below               |
 | showLogo           | boolea         | `true`          | Show the Cloudinary logo on Player       | `false`                      |
 | src                | string         | -               | **Required**: Video public ID            | `"videos/my-video"`          |
 | sourceTypes        | array          | -               | Streaming format                         | `['hls']`                    |
@@ -83,6 +84,18 @@ To customize the logo, the following options are available in the form of an obj
 |--------------------|---------------|----------------|------------------------------------------|
 | imageUrl           | string        | -              | Image URL for player logo.               |
 | onClickUrl         | string        | -              | URL to browse to on logo click.          |
+
+## Customizing a Video's Poster
+
+The `poster` prop optionally takes a string or object to customize the generated poster.
+
+When passing a string, you can either pass a Cloudinary Public ID or a remote URL to rendered the desired image.
+
+When passing an object, use same configuration and API as [getCldImageUrl](/getcldimageurl/configuration) to customize the image.
+You can either specify a `src` option with a custom public ID or omit the `src`, which will use the video's
+ID to render an automatically generated preview image.
+
+[View examples](/cldvideoplayer/examples#poster).
 
 ## Ref Props
 

--- a/docs/pages/cldvideoplayer/configuration.mdx
+++ b/docs/pages/cldvideoplayer/configuration.mdx
@@ -20,23 +20,23 @@ import OgImage from '../../components/OgImage';
 | Prop Name          | Type           | Default         | Description                              | Example                      |
 |--------------------|----------------|-----------------|------------------------------------------|------------------------------|
 | autoPlay           | string         | `"never"`       | When, if, should the video automatically play. See `autoplayMode` in [Video Player docs](https://cloudinary.com/documentation/video_player_api_reference#constructor_parameters) | `"on-scroll"`          |
-| className          | string         | -               | Additional class names added to the video container | `"my-video-player"`      |
-| colors             | object         | See below       | Player chrome colors                     | See Customizing the Player Theme Colors Below             |
+| className          | string         | -               | Additional class names added to the video container | `"my-video-player"` |
+| colors             | object         | See below       | Player chrome colors                     | See Theme Colors Below       |
 | controls           | boolean        | `true`          | Show player controls                     | `true`                       |
 | fontFace           | string         | -               | Player UI font. Uses Google Fonts.       | `"Source Serif Pro"`         |
 | height             | string/number  | -               | **Required**: Player height              | `1080`                       |
 | id                 | string         | -               | Video instance ID, defaults to src value | `"my-video"`                 |
-| logo               | boolean/object | See Below       | Logo to display in Player UI             | See Setting a Custom Logo Below |
+| logo               | boolean/object | See Below       | Logo to display in Player UI             | See Custom Logo Below        |
 | loop               | boolean        | `false`         | Loop the video                           | `true`                       |
 | muted              | boolean        | `false`         | Load muted by default                    | `true`                       |
-| onDataLoad         | Function       | -               | Triggered when video metadata is loaded  | See Custom Event Handlers Below             |
-| onError            | Function       | -               | Triggered on video error                 | See Custom Event Handlers Below             |
-| onMetadataLoad     | Function       | -               | Triggered when video data is loaded      | See Custom Event Handlers Below             |
-| onPause            | Function       | -               | Triggered on video pause                 | See Custom Event Handlers Below             |
-| onPlay             | Function       | -               | Triggered on video play                  | See Custom Event Handlers Below             |
-| onEnded            | Function       | -               | Triggered when video has ended play      | See Custom Event Handlers Below             |
+| onDataLoad         | Function       | -               | Triggered when video metadata is loaded  | See Event Handlers Below     |
+| onError            | Function       | -               | Triggered on video error                 | See Event Handlers Below     |
+| onMetadataLoad     | Function       | -               | Triggered when video data is loaded      | See Event Handlers Below     |
+| onPause            | Function       | -               | Triggered on video pause                 | See Event Handlers Below     |
+| onPlay             | Function       | -               | Triggered on video play                  | See Event Handlers Below     |
+| onEnded            | Function       | -               | Triggered when video has ended play      | See Event Handlers Below     |
 | playerRef          | Ref            | -               | React ref to access Player instance      | See Refs Below               |
-| poster             | string/object  | -               | Customize the video's poster             | See Customizing a Video's Poster Below            |
+| poster             | string/object  | -               | Customize the video's poster             | See Poster Below             |
 | showLogo           | boolea         | `true`          | Show the Cloudinary logo on Player       | `false`                      |
 | src                | string         | -               | **Required**: Video public ID            | `"videos/my-video"`          |
 | sourceTypes        | array          | -               | Streaming format                         | `['hls']`                    |
@@ -46,31 +46,9 @@ import OgImage from '../../components/OgImage';
 
 Missing an option from the [Video Player docs](https://cloudinary.com/documentation/video_player_api_reference) you'd like to see? [Create an issue](https://github.com/colbyfayock/next-cloudinary/issues/new?assignees=&labels=Type%3A+Feature&template=feature_request.md&title=%5BFeature%5D+)!
 
-## Customizing the Player Theme Colors
+## Customization
 
-The `colors` prop takes an object that can control what colors are used in the player:
-
-| Prop Name          | Type          | Default        | Description                              |
-|--------------------|---------------|----------------|------------------------------------------|
-| accent             | string        | `"#FF620C"`    | Seek bar, volume control and for highlighting interactions. |
-| base               | string        | `"#000000"`    | Player controls bar, information bar, central play button, and right-click context menu. |
-| text               | string        | `"#FFFFFF"`    | All the text and icons that are present within the video player UI. |
-
-Learn more about the color scheme options and how they're used [on the Cloudinary docs](https://cloudinary.com/documentation/video_player_customization#color_scheme).
-
-## Custom Event Handlers
-
-The event props allow you to pass in a function that is called whenever the associated event occurs.
-
-For instance, in order to trigger an event whenever a video is paused:
-
-```jsx copy
-<CldVideoPlayer onPause={({ player }) => {
-  const duration = player.duration();
-}} ... />
-```
-
-## Setting a Custom Logo
+### Logo
 
 The `logo` prop gives the option to customize the player's logo.
 
@@ -85,7 +63,7 @@ To customize the logo, the following options are available in the form of an obj
 | imageUrl           | string        | -              | Image URL for player logo.               |
 | onClickUrl         | string        | -              | URL to browse to on logo click.          |
 
-## Customizing a Video's Poster
+### Poster
 
 The `poster` prop optionally takes a string or object to customize the generated poster.
 
@@ -96,8 +74,33 @@ You can either specify a `src` option with a custom public ID or omit the `src`,
 ID to render an automatically generated preview image.
 
 [View examples](/cldvideoplayer/examples#poster).
+### Theme Colors
 
-## Refs
+The `colors` prop takes an object that can control what colors are used in the player:
+
+| Prop Name          | Type          | Default        | Description                              |
+|--------------------|---------------|----------------|------------------------------------------|
+| accent             | string        | `"#FF620C"`    | Seek bar, volume control and for highlighting interactions. |
+| base               | string        | `"#000000"`    | Player controls bar, information bar, central play button, and right-click context menu. |
+| text               | string        | `"#FFFFFF"`    | All the text and icons that are present within the video player UI. |
+
+Learn more about the color scheme options and how they're used [on the Cloudinary docs](https://cloudinary.com/documentation/video_player_customization#color_scheme).
+
+## Player APIs
+
+### Event Handlers
+
+The event props allow you to pass in a function that is called whenever the associated event occurs.
+
+For instance, in order to trigger an event whenever a video is paused:
+
+```jsx copy
+<CldVideoPlayer onPause={({ player }) => {
+  const duration = player.duration();
+}} ... />
+```
+
+### Refs
 
 The `playerRef` and `videoRef` props give you the ability to pass in your own ref to gain access to both the Player instance as well as the HTML video element on which the player is mounted.
 

--- a/docs/pages/cldvideoplayer/examples.mdx
+++ b/docs/pages/cldvideoplayer/examples.mdx
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import Head from 'next/head';
 import { Callout } from 'nextra-theme-docs';
 
-import { CldVideoPlayer } from '../../../next-cloudinary';
+import { CldVideoPlayer, getCldImageUrl } from '../../../next-cloudinary';
 
 import OgImage from '../../components/OgImage';
 import ImageGrid from '../../components/ImageGrid';
@@ -39,14 +39,16 @@ export const VideoPlayerWithRef = (props) => {
 
 <ImageGrid columns={1}>
   <li>
+    ### Default
+
+    <br />
+
     <CldVideoPlayer
       id="default"
       width="1620"
       height="1080"
       src={`${process.env.VIDEOS_DIRECTORY}/mountain-stars`}
     />
-
-    ### Default
 
     Basic settings to display a video.
 
@@ -57,6 +59,11 @@ export const VideoPlayerWithRef = (props) => {
     ```
   </li>
   <li>
+
+    ### Adaptive Streaming
+
+    <br />
+
     <CldVideoPlayer
       id="adaptive-streaming"
       width="1620"
@@ -67,8 +74,6 @@ export const VideoPlayerWithRef = (props) => {
       }}
       sourceTypes={['hls']}
     />
-
-    ### Adaptive Streaming
 
     Basic settings to display a video.
 
@@ -83,6 +88,10 @@ export const VideoPlayerWithRef = (props) => {
     ```
   </li>
   <li>
+    ### Crop & Resize
+
+    <br />
+
     <div style={{ maxWidth: 500, margin: '0 auto' }}>
       <CldVideoPlayer
         id="crop-resize"
@@ -98,8 +107,6 @@ export const VideoPlayerWithRef = (props) => {
       />
     </div>
 
-    ### Crop & Resize
-
     Basic settings to display a video.
 
     ```jsx copy
@@ -109,6 +116,10 @@ export const VideoPlayerWithRef = (props) => {
     ```
   </li>
   <li>
+    ### Transformation: overlay
+
+    <br />
+
     <CldVideoPlayer
       id="transformation-overlay"
       width="1620"
@@ -123,8 +134,6 @@ export const VideoPlayerWithRef = (props) => {
         opacity: 80
       }}
     />
-
-    ### Transformation: overlay
 
     Adding a watermark to a video.
 
@@ -141,6 +150,10 @@ export const VideoPlayerWithRef = (props) => {
     ```
   </li>
   <li>
+    ### Custom Player Colors & Font
+
+    <br />
+
     <CldVideoPlayer
       id="custom-colors-font"
       width="4096"
@@ -154,8 +167,6 @@ export const VideoPlayerWithRef = (props) => {
       fontFace="Source Serif Pro"
     />
 
-    ### Custom Player Colors & Font
-
     Changing the player theme using colors and fonts
 
     ```jsx copy
@@ -168,6 +179,10 @@ export const VideoPlayerWithRef = (props) => {
     ```
   </li>
   <li>
+    ### Custom Logo
+
+    <br />
+
     <CldVideoPlayer
       id="custom-logo"
       width="4096"
@@ -179,8 +194,6 @@ export const VideoPlayerWithRef = (props) => {
       }}
     />
 
-    ### Custom Logo
-
     Adding a custom logo to the player chrome
 
     ```jsx copy
@@ -191,14 +204,77 @@ export const VideoPlayerWithRef = (props) => {
     ```
   </li>
   <li>
+    ### Poster
+
+    <br />
+
+    <CldVideoPlayer
+      id="custom-poster-1"
+      width="4096"
+      height="2160"
+      src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
+      poster={{
+        tint: 'equalize:80:blue:blueviolet'
+      }}
+    />
+
+    Adding effects to the video's auto-generated thumb
+
+    ```jsx copy
+    poster={{
+      tint: 'equalize:80:blue:blueviolet'
+    }}
+    ```
+
+    <br />
+
+    <CldVideoPlayer
+      id="custom-poster-2"
+      width="4096"
+      height="2160"
+      src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
+      poster={getCldImageUrl({ src: `${process.env.IMAGES_DIRECTORY}/turtle` })}
+    />
+
+    Specifying a remote URL
+
+    ```jsx copy
+    poster="https://...com/image.jpg"
+    ```
+
+    <br />
+
+    <CldVideoPlayer
+      id="custom-poster-3"
+      width="4096"
+      height="2160"
+      src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
+      poster={{
+        src: `${process.env.IMAGES_DIRECTORY}/turtle`,
+        tint: 'equalize:80:blue:blueviolet'
+      }}
+    />
+
+    Using a Cloudinary image with effects
+
+    ```jsx copy
+    poster={{
+      src: `${process.env.IMAGES_DIRECTORY}/turtle`,
+      tint: 'equalize:80:blue:blueviolet'
+    }}
+    ```
+  </li>
+  <li>
+    ### With Ref on Callback
+
+    <br />
+
     <VideoPlayerWithRef
       id="with-ref"
       width="4096"
       height="2160"
       src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
     />
-
-    ### With Ref on Callback
 
     Using a ref to access the player instance
 

--- a/docs/pages/getcldvideourl/_meta.json
+++ b/docs/pages/getcldvideourl/_meta.json
@@ -1,0 +1,5 @@
+{
+  "basic-usage": "Basic Usage",
+  "configuration": "Configuration",
+  "examples": "Examples"
+}

--- a/docs/pages/getcldvideourl/basic-usage.mdx
+++ b/docs/pages/getcldvideourl/basic-usage.mdx
@@ -1,0 +1,86 @@
+import Head from 'next/head';
+import { Callout } from 'nextra-theme-docs';
+
+import { CldImage, getCldVideoUrl } from '../../../next-cloudinary';
+
+import OgImage from '../../components/OgImage';
+import Video from '../../components/Video';
+
+<Head>
+  <title>getCldVideoUrl - Next Cloudinary</title>
+  <meta name="og:title" content="Getting Started with getCldVideoUrl - Next Cloudinary" />
+  <meta name="og:url" content={`https://next.cloudinary.dev/getcldvideourl/basic-usage`} />
+</Head>
+
+<OgImage
+  title="getCldVideoUrl"
+  twitterTitle="Getting Started with getCldVideoUrl"
+/>
+
+# Getting Started with getCldVideoUrl
+
+You can use the getCldVideoUrl helper function to generate Cloudinary URLs without the component wrapper.
+
+getCldOgImageUrl is a deritive of [getCldImageUrl](/getcldimageurl/basic-usage) meaning it generally has the same API, but provides a few defaults for videos in particular, setting the asset type to video and doesn't make available image-specific transformations.
+
+## Basic Usage
+
+The basic required options include `width`, `height`, and `src`:
+
+```js copy
+import { getCldVideoUrl } from 'next-cloudinary';
+
+const url = getCldVideoUrl({
+  width: 960,
+  height: 600,
+  src: '<Public ID>'
+});
+```
+
+<div style={{ maxWidth: 500, margin: '0 auto' }}>
+  <video
+    width="1620"
+    height="1080"
+    src={getCldVideoUrl({
+      src: `${process.env.VIDEOS_DIRECTORY}/dog-running-snow`,
+      width: 1620,
+      height: 1080,
+    })}
+    controls
+    muted
+  />
+</div>
+
+## Transformations
+
+You can further take advantage of Cloudinary features like dynamically cropping and resizing:
+
+```js copy
+const url = getCldVideoUrl({
+  src: '<Public ID>',
+  width: 1080,
+  height: 1080,
+  crop: 'fill',
+  gravity: 'auto'
+});
+```
+
+<div style={{ maxWidth: 500, margin: '0 auto' }}>
+  <video
+    width="1080"
+    height="1080"
+    src={getCldVideoUrl({
+      src: `${process.env.VIDEOS_DIRECTORY}/dog-running-snow`,
+      width: 1080,
+      height: 1080,
+      crop: 'fill',
+      gravity: 'auto'
+    })}
+    controls
+    muted
+  />
+</div>
+
+## Learn More about getCldVideoUrl
+* [Configuration](/getcldvideourl/configuration)
+* [Examples](/getcldvideourl/examples)

--- a/docs/pages/getcldvideourl/configuration.mdx
+++ b/docs/pages/getcldvideourl/configuration.mdx
@@ -1,0 +1,28 @@
+import Head from 'next/head';
+
+import OgImage from '../../components/OgImage';
+
+<Head>
+  <title>getCldImageUrl Configuration - Next Cloudinary</title>
+  <meta name="og:title" content="getCldImageUrl Configuration - Next Cloudinary" />
+  <meta name="og:url" content={`https://next.cloudinary.dev/getcldimageurl/configuration`} />
+</Head>
+
+<OgImage
+  title="getCldImageUrl Configuration"
+  twitterTitle="getCldImageUrl Configuration"
+/>
+
+# getCldImageUrl Configuration
+
+Configuration for getCldVideoUrl is the same as [getCldImageUrl](/getcldimageurl/configuration).
+
+The only difference is getCldVideoUrl provides the following default settings:
+
+| Option Name        | Type               | Default    |
+|--------------------|--------------------|------------|
+| assetType          | string             | `"video"`  |
+
+Additionally, the transformations do not have access to image-specific transformations.
+
+Find more configuration settings over at [getCldImageUrl configuration](/getcldimageurl/configuration).

--- a/docs/pages/getcldvideourl/examples.mdx
+++ b/docs/pages/getcldvideourl/examples.mdx
@@ -1,0 +1,77 @@
+import Head from 'next/head';
+import { Callout } from 'nextra-theme-docs';
+
+import { CldImage, getCldVideoUrl } from '../../../next-cloudinary';
+
+import OgImage from '../../components/OgImage';
+import ImageGrid from '../../components/ImageGrid';
+
+<Head>
+  <title>getCldVideoUrl Examples - Next Cloudinary</title>
+  <meta name="og:title" content="getCldVideoUrl Examples - Next Cloudinary" />
+  <meta name="og:url" content={`https://next.cloudinary.dev/getcldvideourl/examples`} />
+</Head>
+
+<OgImage
+  title="getCldVideoUrl Examples"
+  twitterTitle="getCldVideoUrl Examples"
+/>
+
+# getCldVideoUrl Examples
+
+<ImageGrid columns={1}>
+  <li>
+    ### Basic
+
+    <br />
+
+    <video
+      width="1620"
+      height="1080"
+      src={getCldVideoUrl({
+        src: `${process.env.VIDEOS_DIRECTORY}/dog-running-snow`,
+        width: 1620,
+        height: 1080,
+      })}
+      controls
+      muted
+    />
+
+    ```js copy
+    getCldImageUrl({
+      src: 'videos/dog-running-snow',
+      width: 1620,
+      height: 1080,
+    })
+    ```
+  </li>
+  <li>
+    ### Cropping & Resizing
+
+    <br />
+
+    <video
+      width="1080"
+      height="1080"
+      src={getCldVideoUrl({
+        src: `${process.env.VIDEOS_DIRECTORY}/dog-running-snow`,
+        width: 1080,
+        height: 1080,
+        crop: 'fill',
+        gravity: 'auto'
+      })}
+      controls
+      muted
+    />
+
+    ```js copy
+    getCldImageUrl({
+      src: 'videos/dog-running-snow',
+      width: 1080,
+      height: 1080,
+      crop: 'fill',
+      gravity: 'auto'
+    })
+    ```
+  </li>
+</ImageGrid>

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -153,10 +153,17 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
       }
 
       if ( typeof poster === 'string' ) {
+        // If poster is a string, assume it's either a public ID
+        // or a remote URL, in either case pass to `publicId`
         playerOptions.posterOptions = {
           publicId: poster
         };
       } else if ( typeof poster === 'object' ) {
+        // If poster is an object, we can either customize the
+        // automatically generated image from the video or generate
+        // a completely new image from a separate public ID, so look
+        // to see if the src is explicitly set to determine whether 
+        // or not to use the video's ID or just pass things along
         if ( typeof poster.src !== 'string' ) {
           playerOptions.posterOptions = {
             publicId: getCldVideoUrl({

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.tsx
@@ -5,6 +5,8 @@ import { parseUrl } from '@cloudinary-util/util';
 
 import { CldVideoPlayerProps } from './CldVideoPlayer.types';
 import { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsLogo } from '../../types/player';
+import { getCldImageUrl } from '../../helpers/getCldImageUrl';
+import { getCldVideoUrl } from '../../helpers/getCldVideoUrl';
 
 let playerInstances: string[] = [];
 
@@ -29,6 +31,7 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
     onPause,
     onPlay,
     onEnded,
+    poster,
     src,
     sourceTypes,
     transformation,
@@ -147,6 +150,26 @@ const CldVideoPlayer = (props: CldVideoPlayerProps) => {
 
       if ( typeof colors === 'object' ) {
         playerOptions.colors = colors;
+      }
+
+      if ( typeof poster === 'string' ) {
+        playerOptions.posterOptions = {
+          publicId: poster
+        };
+      } else if ( typeof poster === 'object' ) {
+        if ( typeof poster.src !== 'string' ) {
+          playerOptions.posterOptions = {
+            publicId: getCldVideoUrl({
+              ...poster,
+              src: publicId,
+              format: 'auto:image',
+            })
+          };
+        } else {
+          playerOptions.posterOptions = {
+            publicId: getCldImageUrl(poster)
+          };
+        }
       }
 
       playerRef.current = cloudinaryRef.current.videoPlayer(videoRef.current, playerOptions);

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.types.ts
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.types.ts
@@ -2,6 +2,7 @@ import { MutableRefObject } from 'react';
 
 import { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsColors, CloudinaryVideoPlayerOptionsLogo } from '../../types/player';
 import { GetCldImageUrlOptions } from '../../helpers/getCldImageUrl';
+import { GetCldVideoUrlOptions } from '../../helpers/getCldVideoUrl';
 
 export type CldVideoPlayerProps = Pick<CloudinaryVideoPlayerOptions, "colors" | "controls" | "fontFace" | "loop" | "muted" | "sourceTypes" | "transformation"> & {
   autoPlay?: string;
@@ -16,7 +17,7 @@ export type CldVideoPlayerProps = Pick<CloudinaryVideoPlayerOptions, "colors" | 
   onPlay?: Function;
   onEnded?: Function;
   playerRef?: MutableRefObject<CloudinaryVideoPlayer | null>;
-  poster?: string | GetCldImageUrlOptions;
+  poster?: string | GetCldImageUrlOptions | GetCldVideoUrlOptions;
   src: string;
   videoRef?: MutableRefObject<HTMLVideoElement | null>;
   quality?: string | number;

--- a/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.types.ts
+++ b/next-cloudinary/src/components/CldVideoPlayer/CldVideoPlayer.types.ts
@@ -1,6 +1,7 @@
 import { MutableRefObject } from 'react';
 
 import { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsColors, CloudinaryVideoPlayerOptionsLogo } from '../../types/player';
+import { GetCldImageUrlOptions } from '../../helpers/getCldImageUrl';
 
 export type CldVideoPlayerProps = Pick<CloudinaryVideoPlayerOptions, "colors" | "controls" | "fontFace" | "loop" | "muted" | "sourceTypes" | "transformation"> & {
   autoPlay?: string;
@@ -15,6 +16,7 @@ export type CldVideoPlayerProps = Pick<CloudinaryVideoPlayerOptions, "colors" | 
   onPlay?: Function;
   onEnded?: Function;
   playerRef?: MutableRefObject<CloudinaryVideoPlayer | null>;
+  poster?: string | GetCldImageUrlOptions;
   src: string;
   videoRef?: MutableRefObject<HTMLVideoElement | null>;
   quality?: string | number;

--- a/next-cloudinary/src/helpers/getCldImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldImageUrl.ts
@@ -4,20 +4,21 @@ import type { ImageOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-
 import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
 
 /**
- * getCldImage
+ * getCldImageUrl
  */
 
 export interface GetCldImageUrlOptions extends ImageOptions {};
 export interface GetCldImageUrlConfig extends ConfigOptions {};
 export interface GetCldImageUrlAnalytics extends AnalyticsOptions {};
 
+// @deprecated GetCldImageUrl
 export interface GetCldImageUrl {
   options: GetCldImageUrlOptions;
   config?: GetCldImageUrlConfig;
   analytics?: GetCldImageUrlAnalytics;
 }
 
-export function getCldImageUrl(options: ImageOptions, config?: ConfigOptions, analytics?: AnalyticsOptions) {
+export function getCldImageUrl(options: GetCldImageUrlOptions, config?: GetCldImageUrlConfig, analytics?: GetCldImageUrlAnalytics) {
   const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
   return constructCloudinaryUrl({
     options,

--- a/next-cloudinary/src/helpers/getCldOgImageUrl.ts
+++ b/next-cloudinary/src/helpers/getCldOgImageUrl.ts
@@ -7,9 +7,12 @@ import type { GetCldImageUrl, GetCldImageUrlOptions } from './getCldImageUrl';
  * getCldImageUrl
  */
 
+// @deprecated GetCldOgImageUrl
 export interface GetCldOgImageUrl extends GetCldImageUrl {}
 
-export function getCldOgImageUrl(options: GetCldImageUrlOptions) {
+export interface GetCldOgImageUrlOptions extends GetCldImageUrlOptions {};
+
+export function getCldOgImageUrl(options: GetCldOgImageUrlOptions) {
   return getCldImageUrl({
     ...options,
     crop: options.crop || 'fill',

--- a/next-cloudinary/src/helpers/getCldVideoUrl.ts
+++ b/next-cloudinary/src/helpers/getCldVideoUrl.ts
@@ -1,0 +1,33 @@
+import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
+import type { VideoOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
+
+import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
+
+/**
+ * getCldImage
+ */
+
+export interface GetCldVideoUrlOptions extends VideoOptions {};
+export interface GetCldVideoUrlConfig extends ConfigOptions {};
+export interface GetCldVideoUrlAnalytics extends AnalyticsOptions {};
+
+export function getCldVideoUrl(options: GetCldVideoUrlOptions, config?: GetCldVideoUrlConfig, analytics?: GetCldVideoUrlAnalytics) {
+  const cloudName = config?.cloud?.cloudName ?? process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+  return constructCloudinaryUrl({
+    options: {
+      assetType: 'video',
+      ...options
+    },
+    config: Object.assign({
+      cloud: {
+        cloudName: cloudName
+      },
+    }, config),
+    analytics: Object.assign({
+      sdkCode: NEXT_CLOUDINARY_ANALYTICS_ID,
+      sdkSemver: NEXT_CLOUDINARY_VERSION,
+      techVersion: NEXT_VERSION,
+      feature: ''
+    }, analytics)
+  });
+}

--- a/next-cloudinary/src/helpers/getCldVideoUrl.ts
+++ b/next-cloudinary/src/helpers/getCldVideoUrl.ts
@@ -4,7 +4,7 @@ import type { VideoOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-
 import { NEXT_CLOUDINARY_ANALYTICS_ID, NEXT_CLOUDINARY_VERSION, NEXT_VERSION } from '../constants/analytics';
 
 /**
- * getCldImage
+ * getCldVideoUrl
  */
 
 export interface GetCldVideoUrlOptions extends VideoOptions {};

--- a/next-cloudinary/src/index.ts
+++ b/next-cloudinary/src/index.ts
@@ -17,9 +17,14 @@ export { cloudinaryLoader } from './loaders/cloudinary-loader';
 export type { CloudinaryLoader, CloudinaryLoaderLoaderOptions, CloudinaryLoaderCldOptions } from './loaders/cloudinary-loader';
 
 export { getCldImageUrl } from './helpers/getCldImageUrl';
+// @deprecated GetCldImageUrl
 export type { GetCldImageUrl, GetCldImageUrlOptions, GetCldImageUrlConfig, GetCldImageUrlAnalytics } from './helpers/getCldImageUrl';
 
 export { getCldOgImageUrl } from './helpers/getCldOgImageUrl';
-export type { GetCldOgImageUrl } from './helpers/getCldOgImageUrl';
+// @deprecated GetCldOgImageUrl
+export type { GetCldOgImageUrl, GetCldOgImageUrlOptions } from './helpers/getCldOgImageUrl';
+
+export { getCldVideoUrl } from './helpers/getCldVideoUrl';
+export type { GetCldVideoUrlOptions, GetCldVideoUrlConfig, GetCldVideoUrlAnalytics } from './helpers/getCldVideoUrl';
 
 export type { CloudinaryVideoPlayer, CloudinaryVideoPlayerOptions, CloudinaryVideoPlayerOptionsColors, CloudinaryVideoPlayerOptionsLogo } from './types/player';

--- a/next-cloudinary/src/types/player.ts
+++ b/next-cloudinary/src/types/player.ts
@@ -10,6 +10,7 @@ export interface CloudinaryVideoPlayerOptions {
   fontFace?: string;
   loop?: boolean;
   muted?: boolean;
+  posterOptions?: CloudinaryVideoPlayerOptionPosterOptions;
   publicId: string;
   secure?: boolean;
   transformation?: Array<object> | object;
@@ -29,4 +30,8 @@ export interface CloudinaryVideoPlayerOptionsLogo {
   logoImageUrl?: string;
   logoOnclickUrl?: string;
   showLogo?: boolean;
+}
+
+export interface CloudinaryVideoPlayerOptionPosterOptions {
+  publicId: string;
 }

--- a/next-cloudinary/tests/lib/cloudinary.spec.js
+++ b/next-cloudinary/tests/lib/cloudinary.spec.js
@@ -1,4 +1,5 @@
 import { getCldImageUrl } from '../../src/helpers/getCldImageUrl';
+import { getCldVideoUrl } from '../../src/helpers/getCldVideoUrl';
 
 describe('Cloudinary', () => {
   const OLD_ENV = process.env;
@@ -12,7 +13,7 @@ describe('Cloudinary', () => {
     process.env = OLD_ENV;
   });
 
-  describe('getCldImage', () => {
+  describe('getCldImageUrl', () => {
     it('should pass', () => {
       const cloudName = 'customtestcloud';
 
@@ -25,6 +26,22 @@ describe('Cloudinary', () => {
       });
 
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+    });
+  });
+
+  describe('getCldVideoUrl', () => {
+    it('should pass', () => {
+      const cloudName = 'customtestcloud';
+
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = cloudName;
+
+      const url = getCldVideoUrl({
+        src: 'turtle',
+        width: 100,
+        height: 100
+      });
+
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/video/upload/c_limit,w_100/f_auto/q_auto/turtle`);
     });
   });
 })


### PR DESCRIPTION
# Description

Adds the ability to customize the Video Player's poster in a few different ways.

1. String - Public ID or Remote URL

```
poster="publicId"
poster="https://...com/image.jpg
```

2. Object - Customizing the poster image auto-generated from the video 

```
poster={{
  tint: 'equalize:80:blue:blueviolet'
}}
```

This uses the same API as getCldVideoUrl with a format of image to generate an image from the video.

Note: this is very similar to getCldImageUrl, only the asset type is video and some options may be slightly different depending on what is supported on the video asset type. It's for the most part the same API as getCldImageUrl.

3. Object - Custom poster image using a different Cloudinary Public ID

```
poster={{
  src: 'publicId',
  tint: 'equalize:80:blue:blueviolet'
}}
```

Same as #2, only this is explicitly an image and uses getCldImageUrl


Also:
- Adds a new getCldVideoUrl helper which supports the above work
- Marks in the code deprecation of types that don't actually do anything for the helper functions, will remove on next major in case for some reason they're being imported
- Updates helper function types to use the appropriate helper-specific types intended to future-proof usage
- Cleaned up the Examples page for the Player a little bit to be easier to consume

## Issue Ticket Number

Fixes #322 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
