### PR TITLE
Fixes CldUploadWidget onError Callback

### DIFF
--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -240,7 +240,7 @@ const CldUploadWidget = ({
 
   function createWidget() {
     return cloudinary.current?.createUploadWidget(uploadOptions, (uploadError: CldUploadWidgetError, uploadResult: CldUploadWidgetResults) => {
-      if ( typeof uploadError == 'string' ) {
+      if ( uploadError && uploadError !== null ) {
         setError(uploadError);
       }
 

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -58,7 +58,10 @@ export interface CldUploadWidgetInstanceMethods {
   update: (options: CldUploadWidgetUpdateInstanceMethodOptions) => void;
 }
 
-export type CldUploadWidgetError = string | null;
+export type CldUploadWidgetError = {
+  status: string;
+  statusText: string;
+} | string | null;
 
 export interface CldUploadWidgetProps {
   children?: ({ cloudinary, widget, open, results, error }: CldUploadWidgetPropsChildren) => JSX.Element;


### PR DESCRIPTION
# Description

CldUploadWidget error types did not include an object. It was also only being checked for a string, preventing it from properly updating state.

This corrects the types to add the object shape and checks simply if it exists and isnt null.

## Issue Ticket Number

Fixes #355 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
