### PR TITLE
fix: remove assetType from `image` tag

### DIFF
--- a/docs/pages/cldimage/configuration.mdx
+++ b/docs/pages/cldimage/configuration.mdx
@@ -1448,7 +1448,7 @@ Create an image thumbnail from a video asset:
 assetType="video"
 ```
 
-[Learn more about Delivery Types](https://cloudinary.com/documentation/image_transformations#delivery_types) on the Cloudinary docs.
+[Learn more about Asset Types](https://cloudinary.com/documentation/image_transformations#transformation_url_structure) on the Cloudinary docs.
 
 
 #### `config`

--- a/docs/pages/cldimage/configuration.mdx
+++ b/docs/pages/cldimage/configuration.mdx
@@ -1383,6 +1383,13 @@ underlays={[{
   ]}
   data={[
     {
+      prop: 'assetType',
+      type: 'string',
+      default: () => (<code>image</code>),
+      example: () => (<code>video</code>),
+      more: () => (<a className="whitespace-nowrap" href="https://cloudinary.com/documentation/image_transformations#transformation_url_structure">More Info</a>)
+    },
+    {
       prop: 'config',
       type: 'object',
       default: '-',
@@ -1426,6 +1433,23 @@ underlays={[{
     },
   ]}
 />
+
+#### `assetType`
+
+Configures the asset type for the delivered resource.
+
+This defaults to an image for the CldImage component.
+
+**Examples**
+
+Create an image thumbnail from a video asset:
+
+```jsx copy
+assetType="video"
+```
+
+[Learn more about Delivery Types](https://cloudinary.com/documentation/image_transformations#delivery_types) on the Cloudinary docs.
+
 
 #### `config`
 

--- a/docs/pages/cldimage/examples.mdx
+++ b/docs/pages/cldimage/examples.mdx
@@ -990,6 +990,40 @@ Text overlays allow you to place text on top of an image.
   ```
 </CodeBlock>
 
+## Misc
+
+### Video Thumbnail
+
+`assetType`: Specifies the type of asset to be delivered.
+
+This is handy when wanting to create an image thumbnail from a video, where the asset type would be "video", yet delivering an image.
+
+<HeaderImage>
+  <CldImage
+    assetType="video"
+    width="1920"
+    height="1080"
+    src={`${process.env.VIDEOS_DIRECTORY}/dog-running-snow`}
+    sizes="100vw"
+    alt=""
+  />
+</HeaderImage>
+
+<CodeBlock>
+  ```jsx copy showLineNumbers
+  import { CldImage } from 'next-cloudinary';
+
+  <CldImage
+    assetType="video"
+    width="1920"
+    height="1080"
+    src="<Your Video Public ID>"
+    sizes="100vw"
+    alt=""
+  />
+  ```
+</CodeBlock>
+
 ## More Examples
 
 Find more examples on [Social Card Templates](/templates/social-media-cards).

--- a/next-cloudinary/src/components/CldImage/CldImage.tsx
+++ b/next-cloudinary/src/components/CldImage/CldImage.tsx
@@ -22,7 +22,8 @@ const CldImage = forwardRef<HTMLImageElement, CldImageProps>(function CldImage(p
   const CLD_OPTIONS = [
     'deliveryType',
     'preserveTransformations',
-    'strictTransformations'
+    'strictTransformations',
+    'assetType',
   ];
 
   transformationPlugins.forEach(({ props = [] }) => {


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->
I'd like to filter `assetType` from generated image tag

I had the following warning in console on my next project

```
Warning: React does not recognize the `assetType` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `assettype` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at img
```


## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues/377) ticket for this PR
- [x ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
