### PR TITLE
fix: adding CSS export for video player

### DIFF
--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -15,6 +15,7 @@
       "import": "./dist/helpers.mjs",
       "require": "./dist/helpers.js"
     },
+    "./dist/cld-video-player.css": "./dist/cld-video-player.css",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
# Description

The CSS video player currently isn't able to be imported. The goal here is to include it as an export to fix this.