### PR TITLE
Fixes cld-video-player.css import error

### DIFF
--- a/next-cloudinary/package.json
+++ b/next-cloudinary/package.json
@@ -15,6 +15,7 @@
       "import": "./dist/helpers.mjs",
       "require": "./dist/helpers.js"
     },
+    "./dist/cld-video-player.css": "./dist/cld-video-player.css",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
# Description

in the process of setting up subpath routing foundations using the `export` option in package.json, I forgot to include the CSS file that was being used for the video player styles.

This adds that export so it can be imported properly.

## Issue Ticket Number

Fixes #382 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/next-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
