### PR TITLE
Fix/upload widget types

### DIFF
--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -16,25 +16,28 @@ import {
   CldUploadWidgetResults,
   CldUploadWidgetWidgetInstance,
 } from './CldUploadWidget.types';
-import { checkForCloudName } from '../../lib/cloudinary';
+import {checkForCloudName} from "../../lib/cloudinary";
 
-const WIDGET_WATCHED_EVENTS = ['success', 'display-changed'];
+const WIDGET_WATCHED_EVENTS = [
+  'success',
+  'display-changed'
+];
 
 const WIDGET_EVENTS: { [key: string]: string } = {
-  abort: 'onAbort',
+  'abort': 'onAbort',
   'batch-cancelled': 'onBatchCancelled',
   // 'close': 'onClose', // TODO: should follow other event patterns
   'display-changed': 'onDisplayChanged',
-  publicid: 'onPublicId',
+  'publicid': 'onPublicId',
   'queues-end': 'onQueuesEnd',
   'queues-start': 'onQueuesStart',
-  retry: 'onRetry',
+  'retry': 'onRetry',
   'show-completed': 'onShowCompleted',
   'source-changed': 'onSourceChanged',
-  success: 'onSuccess',
-  tags: 'onTags',
+  'success': 'onSuccess',
+  'tags': 'onTags',
   'upload-added': 'onUploadAdded',
-};
+}
 
 // TODO: update onError to follow CldUploadEventCallback pattern
 // TODO: update onClose to follow CldUploadEventCallback pattern
@@ -74,7 +77,7 @@ const CldUploadWidget = ({
   //Check if Cloud Name exists
   checkForCloudName(process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME);
 
-  if (signed) {
+  if ( signed ) {
     uploadOptions.uploadSignature = generateSignature;
 
     if (!uploadOptions.apiKey) {
@@ -85,22 +88,22 @@ const CldUploadWidget = ({
   // Handle result states and callbacks
 
   useEffect(() => {
-    if (typeof results === 'undefined') return;
+    if ( typeof results === 'undefined' ) return;
 
     const isSuccess = results.event === 'success';
     const isClosed = results.event === 'display-changed' && results.info === 'hidden';
 
-    if (isSuccess && typeof onUpload === 'function') {
+    if ( isSuccess && typeof onUpload === 'function' ) {
       onUpload(results, widget.current);
     }
 
-    if (isClosed && typeof onClose === 'function') {
+    if ( isClosed && typeof onClose === 'function' ) {
       onClose(widget.current);
     }
-  }, [results]);
+  }, [results])
 
   useEffect(() => {
-    if (error && typeof onError === 'function') {
+    if ( error && typeof onError === 'function' ) {
       onError(error, widget.current);
     }
   }, [error]);
@@ -112,7 +115,7 @@ const CldUploadWidget = ({
 
   function handleOnLoad() {
     setIsScriptLoading(false);
-    if (!cloudinary.current) {
+    if ( !cloudinary.current ) {
       cloudinary.current = (window as any).cloudinary;
     }
 
@@ -120,7 +123,7 @@ const CldUploadWidget = ({
     // to trigger widget creation. Optional.
 
     triggerOnIdle(() => {
-      if (!widget.current) {
+      if ( !widget.current ) {
         widget.current = createWidget();
       }
     });
@@ -130,8 +133,8 @@ const CldUploadWidget = ({
     return () => {
       widget.current?.destroy();
       widget.current = undefined;
-    };
-  }, []);
+    }
+  }, [])
 
   /**
    * generateSignature
@@ -139,8 +142,8 @@ const CldUploadWidget = ({
    */
 
   function generateSignature(callback: Function, paramsToSign: object) {
-    if (typeof signatureEndpoint === 'undefined') {
-      throw Error('Failed to generate signature: signatureEndpoint undefined.');
+    if ( typeof signatureEndpoint === 'undefined' ) {
+      throw Error('Failed to generate signature: signatureEndpoint undefined.')
     }
     fetch(signatureEndpoint, {
       method: 'POST',
@@ -160,17 +163,19 @@ const CldUploadWidget = ({
    * https://cloudinary.com/documentation/upload_widget_reference#instance_methods
    */
 
-  function invokeInstanceMethod<TMethod extends keyof CldUploadWidgetInstanceMethods>(
+  function invokeInstanceMethod<
+    TMethod extends keyof CldUploadWidgetInstanceMethods
+  >(
     method: TMethod,
-    options: Parameters<CldUploadWidgetInstanceMethods[TMethod]> = [] as Parameters<
+    options: Parameters<
       CldUploadWidgetInstanceMethods[TMethod]
-    >
+    > = [] as Parameters<CldUploadWidgetInstanceMethods[TMethod]>
   ) {
     if (!widget.current) {
       widget.current = createWidget();
     }
 
-    if (typeof widget?.current[method] === 'function') {
+    if (typeof widget?.current[method] === "function") {
       return widget.current[method](...options);
     }
   }
@@ -206,7 +211,7 @@ const CldUploadWidget = ({
   function open(widgetSource?: CldUploadWidgetOpenWidgetSources, options?: CldUploadWidgetOpenInstanceMethodOptions) {
     invokeInstanceMethod('open', [widgetSource, options]);
 
-    if (typeof onOpen === 'function') {
+    if ( typeof onOpen === 'function' ) {
       onOpen(widget.current);
     }
   }
@@ -230,7 +235,7 @@ const CldUploadWidget = ({
     open,
     show,
     update,
-  };
+  }
 
   /**
    * createWidget
@@ -238,46 +243,38 @@ const CldUploadWidget = ({
    */
 
   function createWidget() {
-    return cloudinary.current?.createUploadWidget(
-      uploadOptions,
-      (uploadError: CldUploadWidgetError, uploadResult: CldUploadWidgetResults) => {
-        if (uploadError && uploadError !== null) {
-          setError(uploadError);
+    return cloudinary.current?.createUploadWidget(uploadOptions, (uploadError: CldUploadWidgetError, uploadResult: CldUploadWidgetResults) => {
+      if ( uploadError && uploadError !== null ) {
+        setError(uploadError);
+      }
+
+      if ( typeof uploadResult?.event === 'string' ) {
+        if ( WIDGET_WATCHED_EVENTS.includes(uploadResult?.event) ) {
+          setResults(uploadResult);
         }
 
-        if (typeof uploadResult?.event === 'string') {
-          if (WIDGET_WATCHED_EVENTS.includes(uploadResult?.event)) {
-            setResults(uploadResult);
-          }
+        const widgetEvent = WIDGET_EVENTS[uploadResult.event] as keyof typeof props;
 
-          const widgetEvent = WIDGET_EVENTS[uploadResult.event] as keyof typeof props;
-
-          if (
-            typeof widgetEvent === 'string' &&
-            typeof props[widgetEvent] === 'function' &&
-            typeof props[widgetEvent]
-          ) {
-            const callback = props[widgetEvent] as CldUploadEventCallback;
-            callback(uploadResult, {
-              widget: widget.current,
-              ...instanceMethods,
-            });
-          }
+        if ( typeof widgetEvent === 'string' && typeof props[widgetEvent] === 'function' && typeof props[widgetEvent] ) {
+          const callback = props[widgetEvent] as CldUploadEventCallback;
+          callback(uploadResult, {
+            widget: widget.current,
+            ...instanceMethods
+          });
         }
       }
-    );
+    });
   }
 
   return (
     <>
-      {typeof children === 'function' &&
-        children({
-          cloudinary: cloudinary.current,
-          widget: widget.current,
-          results,
-          error,
-          isLoading: isScriptLoading,
-          ...instanceMethods,
+      {typeof children === 'function' && children({
+        cloudinary: cloudinary.current,
+        widget: widget.current,
+        results,
+        error,
+        isLoading: isScriptLoading,
+        ...instanceMethods,
         })}
       <Script
         id={`cloudinary-uploadwidget-${Math.floor(Math.random() * 100)}`}

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.tsx
@@ -7,7 +7,7 @@ import {
   CldUploadEventCallback,
   CldUploadWidgetCloseInstanceMethodOptions,
   CldUploadWidgetCloudinaryInstance,
-  CldUploadWidgetDetsroyInstanceMethodOptions,
+  CldUploadWidgetDestroyInstanceMethodOptions,
   CldUploadWidgetError,
   CldUploadWidgetInstanceMethods,
   CldUploadWidgetOpenInstanceMethodOptions,
@@ -16,28 +16,25 @@ import {
   CldUploadWidgetResults,
   CldUploadWidgetWidgetInstance,
 } from './CldUploadWidget.types';
-import {checkForCloudName} from "../../lib/cloudinary";
+import { checkForCloudName } from '../../lib/cloudinary';
 
-const WIDGET_WATCHED_EVENTS = [
-  'success',
-  'display-changed'
-];
+const WIDGET_WATCHED_EVENTS = ['success', 'display-changed'];
 
 const WIDGET_EVENTS: { [key: string]: string } = {
-  'abort': 'onAbort',
+  abort: 'onAbort',
   'batch-cancelled': 'onBatchCancelled',
   // 'close': 'onClose', // TODO: should follow other event patterns
   'display-changed': 'onDisplayChanged',
-  'publicid': 'onPublicId',
+  publicid: 'onPublicId',
   'queues-end': 'onQueuesEnd',
   'queues-start': 'onQueuesStart',
-  'retry': 'onRetry',
+  retry: 'onRetry',
   'show-completed': 'onShowCompleted',
   'source-changed': 'onSourceChanged',
-  'success': 'onSuccess',
-  'tags': 'onTags',
+  success: 'onSuccess',
+  tags: 'onTags',
   'upload-added': 'onUploadAdded',
-}
+};
 
 // TODO: update onError to follow CldUploadEventCallback pattern
 // TODO: update onClose to follow CldUploadEventCallback pattern
@@ -77,7 +74,7 @@ const CldUploadWidget = ({
   //Check if Cloud Name exists
   checkForCloudName(process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME);
 
-  if ( signed ) {
+  if (signed) {
     uploadOptions.uploadSignature = generateSignature;
 
     if (!uploadOptions.apiKey) {
@@ -88,22 +85,22 @@ const CldUploadWidget = ({
   // Handle result states and callbacks
 
   useEffect(() => {
-    if ( typeof results === 'undefined' ) return;
+    if (typeof results === 'undefined') return;
 
     const isSuccess = results.event === 'success';
     const isClosed = results.event === 'display-changed' && results.info === 'hidden';
 
-    if ( isSuccess && typeof onUpload === 'function' ) {
+    if (isSuccess && typeof onUpload === 'function') {
       onUpload(results, widget.current);
     }
 
-    if ( isClosed && typeof onClose === 'function' ) {
+    if (isClosed && typeof onClose === 'function') {
       onClose(widget.current);
     }
-  }, [results])
+  }, [results]);
 
   useEffect(() => {
-    if ( error && typeof onError === 'function' ) {
+    if (error && typeof onError === 'function') {
       onError(error, widget.current);
     }
   }, [error]);
@@ -115,7 +112,7 @@ const CldUploadWidget = ({
 
   function handleOnLoad() {
     setIsScriptLoading(false);
-    if ( !cloudinary.current ) {
+    if (!cloudinary.current) {
       cloudinary.current = (window as any).cloudinary;
     }
 
@@ -123,7 +120,7 @@ const CldUploadWidget = ({
     // to trigger widget creation. Optional.
 
     triggerOnIdle(() => {
-      if ( !widget.current ) {
+      if (!widget.current) {
         widget.current = createWidget();
       }
     });
@@ -133,8 +130,8 @@ const CldUploadWidget = ({
     return () => {
       widget.current?.destroy();
       widget.current = undefined;
-    }
-  }, [])
+    };
+  }, []);
 
   /**
    * generateSignature
@@ -142,8 +139,8 @@ const CldUploadWidget = ({
    */
 
   function generateSignature(callback: Function, paramsToSign: object) {
-    if ( typeof signatureEndpoint === 'undefined' ) {
-      throw Error('Failed to generate signature: signatureEndpoint undefined.')
+    if (typeof signatureEndpoint === 'undefined') {
+      throw Error('Failed to generate signature: signatureEndpoint undefined.');
     }
     fetch(signatureEndpoint, {
       method: 'POST',
@@ -163,19 +160,17 @@ const CldUploadWidget = ({
    * https://cloudinary.com/documentation/upload_widget_reference#instance_methods
    */
 
-  function invokeInstanceMethod<
-    TMethod extends keyof CldUploadWidgetInstanceMethods
-  >(
+  function invokeInstanceMethod<TMethod extends keyof CldUploadWidgetInstanceMethods>(
     method: TMethod,
-    options: Parameters<
+    options: Parameters<CldUploadWidgetInstanceMethods[TMethod]> = [] as Parameters<
       CldUploadWidgetInstanceMethods[TMethod]
-    > = [] as Parameters<CldUploadWidgetInstanceMethods[TMethod]>
+    >
   ) {
     if (!widget.current) {
       widget.current = createWidget();
     }
 
-    if (typeof widget?.current[method] === "function") {
+    if (typeof widget?.current[method] === 'function') {
       return widget.current[method](...options);
     }
   }
@@ -184,14 +179,14 @@ const CldUploadWidget = ({
     invokeInstanceMethod('close', [options]);
   }
 
-  function destroy(options?: CldUploadWidgetDetsroyInstanceMethodOptions) {
+  function destroy(options?: CldUploadWidgetDestroyInstanceMethodOptions) {
     return invokeInstanceMethod('destroy', [options]);
   }
-  
+
   function hide() {
     invokeInstanceMethod('hide');
   }
-  
+
   function isDestroyed() {
     return invokeInstanceMethod('isDestroyed');
   }
@@ -199,7 +194,7 @@ const CldUploadWidget = ({
   function isMinimized() {
     return invokeInstanceMethod('isMinimized');
   }
-  
+
   function isShowing() {
     return invokeInstanceMethod('isShowing');
   }
@@ -211,7 +206,7 @@ const CldUploadWidget = ({
   function open(widgetSource?: CldUploadWidgetOpenWidgetSources, options?: CldUploadWidgetOpenInstanceMethodOptions) {
     invokeInstanceMethod('open', [widgetSource, options]);
 
-    if ( typeof onOpen === 'function' ) {
+    if (typeof onOpen === 'function') {
       onOpen(widget.current);
     }
   }
@@ -235,7 +230,7 @@ const CldUploadWidget = ({
     open,
     show,
     update,
-  }
+  };
 
   /**
    * createWidget
@@ -243,38 +238,46 @@ const CldUploadWidget = ({
    */
 
   function createWidget() {
-    return cloudinary.current?.createUploadWidget(uploadOptions, (uploadError: CldUploadWidgetError, uploadResult: CldUploadWidgetResults) => {
-      if ( uploadError && uploadError !== null ) {
-        setError(uploadError);
-      }
-
-      if ( typeof uploadResult?.event === 'string' ) {
-        if ( WIDGET_WATCHED_EVENTS.includes(uploadResult?.event) ) {
-          setResults(uploadResult);
+    return cloudinary.current?.createUploadWidget(
+      uploadOptions,
+      (uploadError: CldUploadWidgetError, uploadResult: CldUploadWidgetResults) => {
+        if (uploadError && uploadError !== null) {
+          setError(uploadError);
         }
 
-        const widgetEvent = WIDGET_EVENTS[uploadResult.event] as keyof typeof props;
+        if (typeof uploadResult?.event === 'string') {
+          if (WIDGET_WATCHED_EVENTS.includes(uploadResult?.event)) {
+            setResults(uploadResult);
+          }
 
-        if ( typeof widgetEvent === 'string' && typeof props[widgetEvent] === 'function' && typeof props[widgetEvent] ) {
-          const callback = props[widgetEvent] as CldUploadEventCallback;
-          callback(uploadResult, {
-            widget: widget.current,
-            ...instanceMethods
-          });
+          const widgetEvent = WIDGET_EVENTS[uploadResult.event] as keyof typeof props;
+
+          if (
+            typeof widgetEvent === 'string' &&
+            typeof props[widgetEvent] === 'function' &&
+            typeof props[widgetEvent]
+          ) {
+            const callback = props[widgetEvent] as CldUploadEventCallback;
+            callback(uploadResult, {
+              widget: widget.current,
+              ...instanceMethods,
+            });
+          }
         }
       }
-    });
+    );
   }
 
   return (
     <>
-      {typeof children === 'function' && children({
-        cloudinary: cloudinary.current,
-        widget: widget.current,
-        results,
-        error,
-        isLoading: isScriptLoading,
-        ...instanceMethods,
+      {typeof children === 'function' &&
+        children({
+          cloudinary: cloudinary.current,
+          widget: widget.current,
+          results,
+          error,
+          isLoading: isScriptLoading,
+          ...instanceMethods,
         })}
       <Script
         id={`cloudinary-uploadwidget-${Math.floor(Math.random() * 100)}`}

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -231,8 +231,8 @@ export interface CldUploadWidgetPropsOptions {
   showPoweredBy?: boolean;
   showUploadMoreButton?: boolean;
   singleUploadAutoClose?: boolean;
-  detection: string;
-  on_success: string;
+  detection?: string;
+  on_success?: string;
 }
 
 export type CldUploadEventCallback = (results: CldUploadWidgetResults, widget: CldUploadEventCallbackWidget) => void;

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -7,7 +7,7 @@ type CustomURL = `https://${string}.${string}`;
 
 export interface CldUploadWidgetResults {
   event?: string;
-  info?: string | CldUploadWidgetInfo;
+  info?: string | object;
 }
 
 export interface CldUploadWidgetInfo {
@@ -44,15 +44,15 @@ export interface CldUploadWidgetInfo {
 
 export type CldUploadWidgetDestroyInstanceMethodOptions = {
   removeThumbnails: boolean;
-};
+}
 
 export type CldUploadWidgetCloseInstanceMethodOptions = {
   quiet: boolean;
-};
+}
 
 export type CldUploadWidgetOpenInstanceMethodOptions = {
   files: CustomURL[];
-};
+}
 
 export type CldUploadWidgetOpenWidgetSources =
   | 'local'
@@ -71,11 +71,11 @@ export type CldUploadWidgetOpenWidgetSources =
 
 type CldUploadWidgetUpdateInstanceMethodOptions = Omit<
   CldUploadWidgetPropsOptions,
-  'secure' | 'uploadSignature' | 'getTags' | 'preBatch' | 'inlineContainer' | 'fieldName'
+  "secure" | "uploadSignature" | "getTags" | "preBatch" | "inlineContainer" | "fieldName"
 > & {
   cloudName: string;
   uploadPreset: string;
-};
+}
 
 export interface CldUploadWidgetInstanceMethods {
   close: (options?: CldUploadWidgetCloseInstanceMethodOptions) => void;
@@ -90,13 +90,10 @@ export interface CldUploadWidgetInstanceMethods {
   update: (options: CldUploadWidgetUpdateInstanceMethodOptions) => void;
 }
 
-export type CldUploadWidgetError =
-  | {
-      status: string;
-      statusText: string;
-    }
-  | string
-  | null;
+export type CldUploadWidgetError = {
+  status: string;
+  statusText: string;
+} | string | null;
 
 export interface CldUploadWidgetProps {
   children?: ({ cloudinary, widget, open, results, error }: CldUploadWidgetPropsChildren) => JSX.Element;
@@ -139,23 +136,23 @@ export interface CldUploadWidgetPropsOptions {
   encryption?: {
     key: string;
     iv: string;
-  };
+  }
   defaultSource?: string;
   maxFiles?: number;
   multiple?: boolean;
   sources?: Array<
-    | 'camera'
-    | 'dropbox'
-    | 'facebook'
-    | 'gettyimages'
-    | 'google_drive'
-    | 'image_search'
-    | 'instagram'
-    | 'istock'
-    | 'local'
-    | 'shutterstock'
-    | 'unsplash'
-    | 'url'
+    "camera"
+    | "dropbox"
+    | "facebook"
+    | "gettyimages"
+    | "google_drive"
+    | "image_search"
+    | "instagram"
+    | "istock"
+    | "local"
+    | "shutterstock"
+    | "unsplash"
+    | "url"
   >;
 
   // Cropping
@@ -239,10 +236,7 @@ export interface CldUploadWidgetPropsOptions {
 }
 
 export type CldUploadEventCallback = (results: CldUploadWidgetResults, widget: CldUploadEventCallbackWidget) => void;
-export type CldUploadEventCallbackNoOptions = (
-  results: CldUploadWidgetResults,
-  widget: CldUploadWidgetWidgetInstance
-) => void;
+export type CldUploadEventCallbackNoOptions = (results: CldUploadWidgetResults, widget: CldUploadWidgetWidgetInstance) => void;
 export type CldUploadEventCallbackWidgetOnly = (widget: CldUploadWidgetWidgetInstance) => void;
 export type CldUploadEventCallbackError = (error: CldUploadWidgetError, widget: CldUploadWidgetWidgetInstance) => void;
 

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -7,7 +7,7 @@ type CustomURL = `https://${string}.${string}`;
 
 export interface CldUploadWidgetResults {
   event?: string;
-  info?: string | object;
+  info?: string | CldUploadWidgetInfo;
 }
 
 export interface CldUploadWidgetInfo {

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -10,17 +10,17 @@ export interface CldUploadWidgetResults {
   info?: string | object;
 }
 
-export type CldUploadWidgetDetsroyInstanceMethodOptions = {
+export type CldUploadWidgetDestroyInstanceMethodOptions = {
   removeThumbnails: boolean;
-}
+};
 
 export type CldUploadWidgetCloseInstanceMethodOptions = {
   quiet: boolean;
-}
+};
 
 export type CldUploadWidgetOpenInstanceMethodOptions = {
   files: CustomURL[];
-}
+};
 
 export type CldUploadWidgetOpenWidgetSources =
   | 'local'
@@ -34,20 +34,20 @@ export type CldUploadWidgetOpenWidgetSources =
   | 'shutterstock'
   | 'getty'
   | 'istock'
-  | 'unsplash' 
+  | 'unsplash'
   | null;
 
 type CldUploadWidgetUpdateInstanceMethodOptions = Omit<
   CldUploadWidgetPropsOptions,
-  "secure" | "uploadSignature" | "getTags" | "preBatch" | "inlineContainer" | "fieldName"
+  'secure' | 'uploadSignature' | 'getTags' | 'preBatch' | 'inlineContainer' | 'fieldName'
 > & {
   cloudName: string;
   uploadPreset: string;
-}
+};
 
 export interface CldUploadWidgetInstanceMethods {
   close: (options?: CldUploadWidgetCloseInstanceMethodOptions) => void;
-  destroy: (options?: CldUploadWidgetDetsroyInstanceMethodOptions) => Promise<void>;
+  destroy: (options?: CldUploadWidgetDestroyInstanceMethodOptions) => Promise<void>;
   hide: () => void;
   isDestroyed: () => boolean;
   isMinimized: () => boolean;
@@ -58,10 +58,13 @@ export interface CldUploadWidgetInstanceMethods {
   update: (options: CldUploadWidgetUpdateInstanceMethodOptions) => void;
 }
 
-export type CldUploadWidgetError = {
-  status: string;
-  statusText: string;
-} | string | null;
+export type CldUploadWidgetError =
+  | {
+      status: string;
+      statusText: string;
+    }
+  | string
+  | null;
 
 export interface CldUploadWidgetProps {
   children?: ({ cloudinary, widget, open, results, error }: CldUploadWidgetPropsChildren) => JSX.Element;
@@ -104,23 +107,23 @@ export interface CldUploadWidgetPropsOptions {
   encryption?: {
     key: string;
     iv: string;
-  }
+  };
   defaultSource?: string;
   maxFiles?: number;
   multiple?: boolean;
   sources?: Array<
-    "camera"
-    | "dropbox"
-    | "facebook"
-    | "gettyimages"
-    | "google_drive"
-    | "image_search"
-    | "instagram"
-    | "istock"
-    | "local"
-    | "shutterstock"
-    | "unsplash"
-    | "url"
+    | 'camera'
+    | 'dropbox'
+    | 'facebook'
+    | 'gettyimages'
+    | 'google_drive'
+    | 'image_search'
+    | 'instagram'
+    | 'istock'
+    | 'local'
+    | 'shutterstock'
+    | 'unsplash'
+    | 'url'
   >;
 
   // Cropping
@@ -202,7 +205,10 @@ export interface CldUploadWidgetPropsOptions {
 }
 
 export type CldUploadEventCallback = (results: CldUploadWidgetResults, widget: CldUploadEventCallbackWidget) => void;
-export type CldUploadEventCallbackNoOptions = (results: CldUploadWidgetResults, widget: CldUploadWidgetWidgetInstance) => void;
+export type CldUploadEventCallbackNoOptions = (
+  results: CldUploadWidgetResults,
+  widget: CldUploadWidgetWidgetInstance
+) => void;
 export type CldUploadEventCallbackWidgetOnly = (widget: CldUploadWidgetWidgetInstance) => void;
 export type CldUploadEventCallbackError = (error: CldUploadWidgetError, widget: CldUploadWidgetWidgetInstance) => void;
 

--- a/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
+++ b/next-cloudinary/src/components/CldUploadWidget/CldUploadWidget.types.ts
@@ -7,7 +7,39 @@ type CustomURL = `https://${string}.${string}`;
 
 export interface CldUploadWidgetResults {
   event?: string;
-  info?: string | object;
+  info?: string | CldUploadWidgetInfo;
+}
+
+export interface CldUploadWidgetInfo {
+  access_mode: 'public' | 'authenticated';
+  api_key: string;
+  asset_id: string;
+  batchId: string;
+  bytes: number;
+  context: Record<string, Record<string, string>>;
+  created_at: string;
+  etag: string;
+  folder: string;
+  format: string;
+  height: number;
+  hook_execution: Record<string, unknown>;
+  id: string;
+  info: Record<string, unknown>;
+  original_filename: string;
+  pages: number;
+  path: string;
+  placeholder: boolean;
+  public_id: string;
+  resource_type: 'image' | 'raw' | 'video' | 'auto';
+  secure_url: string;
+  signature: string;
+  tags: string[];
+  thumbnail_url: string;
+  type: 'upload' | 'private' | 'authenticated';
+  url: string;
+  version: number;
+  width: number;
+  [key: string]: unknown;
 }
 
 export type CldUploadWidgetDestroyInstanceMethodOptions = {
@@ -202,6 +234,8 @@ export interface CldUploadWidgetPropsOptions {
   showPoweredBy?: boolean;
   showUploadMoreButton?: boolean;
   singleUploadAutoClose?: boolean;
+  detection: string;
+  on_success: string;
 }
 
 export type CldUploadEventCallback = (results: CldUploadWidgetResults, widget: CldUploadEventCallbackWidget) => void;


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->
This PR includes fixes for TypeScript types particularly for the `CldUploadWidget ` component.

This fixes missing types for 2 parameters from the option prop, `detection` and `on_success`

This also fixes the missing types from the info key of the`CldUploadWidgetResults` interface.

## Issue Ticket Number

Fixes #397 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/next-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
